### PR TITLE
fix: `Unexpected token 'with'` error on Windows

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,9 @@
+import { createRequire } from 'module';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
 import systeminformation from 'systeminformation';
-import pkg from '../../package.json' with { type: 'json' };
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 
 export default defineCommand({
   description: 'Prints out neccessary information for debugging',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,8 @@
+import { createRequire } from 'module';
 import { defineConfig, processConfig } from '@robingenz/zli';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import pkg from '../package.json' with { type: 'json' };
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
 
 const config = defineConfig({
   meta: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import * as Sentry from '@sentry/node';
 import { AxiosError } from 'axios';
 import consola from 'consola';
 import { ZodError } from 'zod';
-import pkg from '../package.json' with { type: 'json' };
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
 
 const config = defineConfig({
   meta: {

--- a/src/services/update.ts
+++ b/src/services/update.ts
@@ -1,6 +1,8 @@
+import { createRequire } from 'module';
 import consola from 'consola';
 import * as semver from 'semver';
-import pkg from '../../package.json' with { type: 'json' };
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 import { NpmPackageDto } from '@/types/npm-package.js';
 import httpClient, { HttpClient } from '@/utils/http-client.js';
 

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -1,7 +1,9 @@
+import { createRequire } from 'module';
 import configService from '@/services/config.js';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
-import pkg from '../../package.json' with { type: 'json' };
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json');
 
 // Register middleware to retry failed requests
 axiosRetry(axios, {


### PR DESCRIPTION
> The issue is that the import statement is using the with { type: 'json' } syntax (Import Attributes), which was introduced in Node.js v20.10.0. Your system is running Node.js v18.16.0, which doesn't support this syntax.

Close #74