### PR TITLE
feat: add `mutate:version:*` commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@clack/prompts": "0.7.0",
         "@robingenz/zli": "0.1.5",
         "@sentry/node": "8.55.0",
+        "@trapezedev/project": "7.1.3",
         "archiver": "7.0.1",
         "axios": "1.8.4",
         "axios-retry": "4.5.0",
@@ -67,7 +68,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -82,7 +82,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -121,6 +120,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -569,7 +580,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=6.9.0"
@@ -582,6 +592,219 @@
       "dev": true,
       "peerDependencies": {
         "prettier": "^2.4.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.11.tgz",
+      "integrity": "sha512-Uavxn+x8j3rDlZEk1X7YnaN6wCgbCwYQOeIjv/m94i1dzslqWhqIHEqxEyeE8HsT5Negboagg7GtQiABy+BLbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.6",
+        "@ionic/utils-terminal": "2.3.4",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.6.tgz",
+      "integrity": "sha512-4+Kitey1lTA1yGtnigeYNhV/0tggI3lWBMjC7tBs1K9GXa/q7q4CtOISppdh8QgtOhrhAXS2Igp8rbko/Cj+lA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-2.1.14.tgz",
+      "integrity": "sha512-nGYvyGVjU0kjPUcSRFr4ROTraT3w/7r502f5QJEsMRKTqa4eEzCshtwRk+/mpASm0kgBN5rrjYA5A/OZg8ahqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.6",
+        "@ionic/utils-fs": "3.1.7",
+        "@ionic/utils-process": "2.1.11",
+        "@ionic/utils-stream": "3.1.6",
+        "@ionic/utils-terminal": "2.3.4",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.4.tgz",
+      "integrity": "sha512-cEiMFl3jklE0sW60r8JHH3ijFTwh/jkdEKWbylSyExQwZ8pPuwoXz7gpkWoJRLuoRHHSvg+wzNYyPJazIHfoJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -600,12 +823,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.39.6",
@@ -625,11 +866,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -643,7 +895,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -653,7 +904,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1263,6 +1513,15 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1278,6 +1537,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
+      "integrity": "sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==",
+      "license": "MIT",
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11",
+        "prettier": ">=2.4.0"
+      }
     },
     "node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
@@ -1893,6 +2162,384 @@
         "@opentelemetry/semantic-conventions": "^1.28.0"
       }
     },
+    "node_modules/@trapezedev/gradle-parse": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@trapezedev/gradle-parse/-/gradle-parse-7.1.3.tgz",
+      "integrity": "sha512-WQVF5pEJ5o/mUyvfGTG9nBKx9Te/ilKM3r2IT69GlbaooItT5ao7RyF1MUTBNjHLPk/xpGUY3c6PyVnjDlz0Vw==",
+      "license": "SEE LICENSE"
+    },
+    "node_modules/@trapezedev/project": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@trapezedev/project/-/project-7.1.3.tgz",
+      "integrity": "sha512-GANh8Ey73MechZrryfJoILY9hBnWqzS6AdB53zuWBCBbaiImyblXT41fWdN6pB2f5+cNI2FAUxGfVhl+LeEVbQ==",
+      "license": "SEE LICENSE",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.5",
+        "@ionic/utils-subprocess": "^2.1.8",
+        "@prettier/plugin-xml": "^2.2.0",
+        "@trapezedev/gradle-parse": "7.1.3",
+        "@xmldom/xmldom": "^0.7.5",
+        "conventional-changelog": "^3.1.4",
+        "cross-spawn": "^7.0.3",
+        "diff": "^5.1.0",
+        "env-paths": "^3.0.0",
+        "gradle-to-js": "^2.0.0",
+        "ini": "^2.0.0",
+        "kleur": "^4.1.5",
+        "lodash": "^4.17.21",
+        "mergexml": "^1.2.3",
+        "plist": "^3.0.4",
+        "prettier": "^2.7.1",
+        "prompts": "^2.4.2",
+        "replace": "^1.1.0",
+        "tempy": "^1.0.1",
+        "tmp": "^0.2.1",
+        "ts-node": "^10.2.1",
+        "xcode": "^3.0.1",
+        "xml-js": "^1.6.11",
+        "xpath": "^0.0.32",
+        "yargs": "^17.2.1"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+      "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^5.0.12",
+        "conventional-changelog-atom": "^2.0.8",
+        "conventional-changelog-codemirror": "^2.0.8",
+        "conventional-changelog-conventionalcommits": "^4.5.0",
+        "conventional-changelog-core": "^4.2.1",
+        "conventional-changelog-ember": "^2.0.9",
+        "conventional-changelog-eslint": "^3.0.9",
+        "conventional-changelog-express": "^2.0.6",
+        "conventional-changelog-jquery": "^3.0.11",
+        "conventional-changelog-jshint": "^2.0.9",
+        "conventional-changelog-preset-loader": "^2.3.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-angular": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-atom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-codemirror": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+      "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+      "license": "MIT",
+      "dependencies": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^5.0.0",
+        "conventional-commits-parser": "^3.2.0",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^4.0.0",
+        "git-raw-commits": "^2.0.8",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^4.1.1",
+        "lodash": "^4.17.15",
+        "normalize-package-data": "^3.0.0",
+        "q": "^1.5.1",
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-ember": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-eslint": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-express": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-jquery": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
+      "license": "ISC",
+      "dependencies": {
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-jshint": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-preset-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+      "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-changelog-writer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.7",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-changelog-writer": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-commits-filter": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/conventional-commits-parser": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-text-path": "^1.0.1",
+        "JSONStream": "^1.0.4",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/git-raw-commits": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
+      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^7.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/git-semver-tags": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+      "license": "MIT",
+      "dependencies": {
+        "meow": "^8.0.0",
+        "semver": "^6.0.0"
+      },
+      "bin": {
+        "git-semver-tags": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@trapezedev/project/node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
     "node_modules/@types/archiver": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.3.tgz",
@@ -1936,6 +2583,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.4.tgz",
@@ -1947,7 +2603,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mysql": {
@@ -1972,7 +2627,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/pg": {
@@ -2014,6 +2668,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "license": "MIT"
     },
     "node_modules/@types/tedious": {
@@ -2183,6 +2843,25 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chevrotain": "7.1.1"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2215,11 +2894,22 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -2233,6 +2923,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-regex": {
@@ -2250,7 +2953,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -2307,18 +3009,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2328,11 +3034,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2344,6 +3055,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -2353,6 +3073,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.8.4",
@@ -2412,6 +3141,15 @@
         }
       ]
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2425,11 +3163,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bplist-creator": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+      "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
+      "license": "MIT",
+      "dependencies": {
+        "stream-buffers": "2.2.x"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+      "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2440,7 +3198,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2557,7 +3314,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2567,7 +3323,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -2602,7 +3357,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -2621,6 +3375,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/chokidar": {
@@ -2661,11 +3424,19 @@
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "license": "MIT"
     },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2680,7 +3451,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2690,7 +3460,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2706,7 +3475,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2719,21 +3487,18 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2748,7 +3513,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2761,7 +3525,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2779,7 +3542,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -2789,7 +3551,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2848,7 +3609,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-ify": "^1.0.0",
@@ -2874,7 +3634,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -3190,6 +3949,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3202,6 +3967,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cssstyle": {
@@ -3221,7 +3995,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3245,7 +4018,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3272,7 +4044,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3282,7 +4053,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
       "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "decamelize": "^1.1.0",
@@ -3299,7 +4069,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3367,6 +4136,65 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
+    "node_modules/del": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "license": "MIT",
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/del/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3400,11 +4228,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -3417,7 +4263,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3427,7 +4272,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -3565,11 +4409,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -3673,7 +4528,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3683,7 +4537,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -3769,7 +4622,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3786,7 +4638,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3819,7 +4670,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3902,11 +4752,43 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -3931,6 +4813,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3959,7 +4847,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3993,7 +4880,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
       "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hutson/parse-repository-url": "^3.0.0",
@@ -4012,7 +4898,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4022,7 +4907,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4038,7 +4922,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4050,7 +4933,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4063,21 +4945,18 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-pkg-repo/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/get-pkg-repo/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4092,7 +4971,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4105,7 +4983,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -4123,7 +5000,6 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -4204,7 +5080,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "gitconfiglocal": "^1.0.0",
@@ -4235,7 +5110,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
-      "dev": true,
       "license": "BSD",
       "dependencies": {
         "ini": "^1.3.2"
@@ -4266,7 +5140,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4302,7 +5175,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -4336,11 +5208,22 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "node_modules/gradle-to-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gradle-to-js/-/gradle-to-js-2.0.1.tgz",
+      "integrity": "sha512-is3hDn9zb8XXnjbEeAEIqxTpLHUiGBqjegLmXPuyMBfKAggpadWFku4/AP8iYAGBX6qR9/5UIUIp47V0XI3aMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.merge": "^4.6.2"
+      },
+      "bin": {
+        "gradle-to-js": "cli.js"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -4362,7 +5245,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4372,7 +5254,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4420,7 +5301,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4515,7 +5395,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4537,10 +5416,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -4552,14 +5441,12 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
@@ -4590,7 +5477,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4608,7 +5494,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4661,7 +5546,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4671,7 +5555,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4681,7 +5582,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4721,7 +5621,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "text-extensions": "^1.0.0"
@@ -4770,7 +5669,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -4818,28 +5716,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -4849,7 +5755,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
@@ -4866,10 +5771,18 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lazystream": {
@@ -4914,14 +5827,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -4937,7 +5848,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4968,7 +5878,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -4982,7 +5897,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -5001,11 +5915,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5027,7 +5946,6 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
       "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimist": "^1.2.0",
@@ -5053,7 +5971,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -5067,14 +5984,12 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/meow/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -5087,7 +6002,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -5103,7 +6017,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -5116,7 +6029,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -5135,7 +6047,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
@@ -5151,7 +6062,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.1.0",
@@ -5169,7 +6079,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -5179,7 +6088,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -5192,7 +6100,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -5202,7 +6109,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -5218,17 +6124,35 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mergexml": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mergexml/-/mergexml-1.2.4.tgz",
+      "integrity": "sha512-yiOlDqcVCz7AG1eSboonc18FTlfqDEKYfGoAV3Lul98u6YRV/s0kjtf4bjk47t0hLTFJR0BSYMd6BpmX3xDjNQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.0",
+        "formidable": "^3.5.1",
+        "xpath": "0.0.27"
+      }
+    },
+    "node_modules/mergexml/node_modules/xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5288,7 +6212,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5298,7 +6221,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5311,7 +6233,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5321,7 +6242,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "arrify": "^1.0.1",
@@ -5394,7 +6314,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5459,7 +6378,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nock": {
@@ -5533,7 +6451,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
       "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
@@ -5613,6 +6530,15 @@
       "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==",
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -5685,11 +6611,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5706,7 +6646,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-ex": "^1.3.1",
@@ -5733,10 +6672,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5779,7 +6726,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^3.0.0"
@@ -5792,7 +6738,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5861,7 +6806,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5874,7 +6818,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5902,6 +6845,29 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/postcss": {
@@ -5976,7 +6942,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -6011,6 +6976,28 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -6036,6 +7023,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
     "node_modules/queue-lit": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
@@ -6050,7 +7048,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6076,7 +7073,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6096,7 +7092,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "load-json-file": "^4.0.0",
@@ -6111,7 +7106,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
       "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^2.0.0",
@@ -6125,7 +7119,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -6138,7 +7131,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -6152,7 +7144,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^1.0.0"
@@ -6165,7 +7156,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6178,7 +7168,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6188,7 +7177,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6198,14 +7186,12 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -6218,7 +7204,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -6284,7 +7269,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -6294,11 +7278,238 @@
         "node": ">=8"
       }
     },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "license": "MIT"
+    },
+    "node_modules/replace": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/replace/-/replace-1.2.2.tgz",
+      "integrity": "sha512-C4EDifm22XZM2b2JOYe6Mhn+lBsLBAvLbK8drfUQLTfD1KYl/n3VaW/CDju0Ny4w3xTtegBpg8YNSpFJPUDSjA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "2.4.2",
+        "minimatch": "3.0.5",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "replace": "bin/replace.js",
+        "search": "bin/search.js"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/replace/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/replace/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/replace/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/replace/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/replace/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/replace/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/replace/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/replace/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/replace/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/replace/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6317,6 +7528,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6348,7 +7565,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6531,7 +7747,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6577,6 +7792,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -6600,6 +7821,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6644,6 +7871,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-plist": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
+      "integrity": "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==",
+      "license": "MIT",
+      "dependencies": {
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "0.3.1",
+        "plist": "^3.0.5"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
@@ -6668,17 +7906,65 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6698,7 +7984,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -6709,14 +7994,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -6727,14 +8010,12 @@
       "version": "3.0.22",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
       "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "through": "2"
@@ -6747,7 +8028,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "readable-stream": "^3.0.0"
@@ -6757,7 +8037,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6780,6 +8059,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
+    },
+    "node_modules/stream-buffers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/streamx": {
       "version": "2.16.1",
@@ -6900,7 +8188,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6922,7 +8209,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -6955,7 +8241,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -7044,11 +8329,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "license": "MIT",
+      "dependencies": {
+        "del": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -7058,14 +8382,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -7076,7 +8398,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7092,14 +8413,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7217,11 +8536,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7266,14 +8593,74 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/tsc-alias": {
@@ -7336,11 +8723,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -7360,7 +8752,6 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7380,7 +8771,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -7396,16 +8786,60 @@
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -7715,6 +9149,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -7736,7 +9176,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -7850,6 +9289,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -7902,6 +9347,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xcode": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "simple-plist": "^1.1.0",
+        "uuid": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -7912,12 +9382,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -7932,7 +9420,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7960,7 +9447,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7979,7 +9465,6 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7989,7 +9474,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7999,14 +9483,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8021,7 +9503,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8034,10 +9515,18 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@clack/prompts": "0.7.0",
     "@robingenz/zli": "0.1.5",
     "@sentry/node": "8.55.0",
+    "@trapezedev/project": "7.1.3",
     "archiver": "7.0.1",
     "axios": "1.8.4",
     "axios-retry": "4.5.0",

--- a/src/commands/mutate/version/get.test.ts
+++ b/src/commands/mutate/version/get.test.ts
@@ -1,0 +1,103 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import getCommand from './get.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:get', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should display synchronized versions across all platforms', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 0 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+      {
+        platform: 'android' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 0 },
+        source: 'android/app/build.gradle',
+      },
+      { platform: 'web' as const, version: { major: 1, minor: 2, patch: 3 }, source: 'package.json' },
+    ];
+
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+
+    await getCommand.action({}, undefined);
+
+    expect(mockConsola.success).toHaveBeenCalledWith('Version: 1.2.3');
+    expect(mockConsola.log).toHaveBeenCalledWith('  ios: ios/App/App.xcodeproj/project.pbxproj');
+    expect(mockConsola.log).toHaveBeenCalledWith('  android: android/app/build.gradle');
+    expect(mockConsola.log).toHaveBeenCalledWith('  web: package.json');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should display hotfix when iOS/Android have one', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 5 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+      {
+        platform: 'android' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 5 },
+        source: 'android/app/build.gradle',
+      },
+      { platform: 'web' as const, version: { major: 1, minor: 2, patch: 3 }, source: 'package.json' },
+    ];
+
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+
+    await getCommand.action({}, undefined);
+
+    expect(mockConsola.success).toHaveBeenCalledWith('Version: 1.2.3 (hotfix: 5)');
+  });
+
+  it('should error when versions are not synchronized', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 0 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+      {
+        platform: 'android' as const,
+        version: { major: 1, minor: 2, patch: 4, hotfix: 0 },
+        source: 'android/app/build.gradle',
+      },
+      { platform: 'web' as const, version: { major: 1, minor: 2, patch: 3 }, source: 'package.json' },
+    ];
+
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+
+    await expect(getCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(getCommand.action({}, undefined)).rejects.toThrow('Versions are not synchronized across platforms');
+
+    expect(mockConsola.error).toHaveBeenCalledWith('Versions are not synchronized across platforms:');
+    expect(mockConsola.log).toHaveBeenCalledWith('  ios: 1.2.3 (ios/App/App.xcodeproj/project.pbxproj)');
+    expect(mockConsola.log).toHaveBeenCalledWith('  android: 1.2.4 (android/app/build.gradle)');
+    expect(mockConsola.log).toHaveBeenCalledWith('  web: 1.2.3 (package.json)');
+  });
+
+  it('should error when no platform versions found', async () => {
+    mockVersionService.getAllVersions.mockResolvedValue([]);
+
+    await expect(getCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(getCommand.action({}, undefined)).rejects.toThrow('No platform versions found');
+  });
+});

--- a/src/commands/mutate/version/get.ts
+++ b/src/commands/mutate/version/get.ts
@@ -1,0 +1,49 @@
+import versionService from '@/services/mutate/version.js';
+import { versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Get the version of the app from all relevant files',
+  action: async () => {
+    try {
+      const versions = await versionService.getAllVersions();
+
+      if (versions.length === 0) {
+        consola.error('No platform versions found');
+        process.exit(1);
+      }
+
+      const firstVersion = versions[0]!.version;
+      const allInSync = versions.every((pv) => {
+        return (
+          pv.version.major === firstVersion.major &&
+          pv.version.minor === firstVersion.minor &&
+          pv.version.patch === firstVersion.patch &&
+          pv.version.hotfix === firstVersion.hotfix
+        );
+      });
+
+      if (!allInSync) {
+        consola.error('Versions are not synchronized across platforms:');
+        versions.forEach((pv) => {
+          const versionStr = versionToString(pv.version);
+          const hotfixStr = pv.version.hotfix > 0 ? ` (hotfix: ${pv.version.hotfix})` : '';
+          consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`);
+        });
+        process.exit(1);
+      }
+
+      const versionStr = versionToString(firstVersion);
+      const hotfixStr = firstVersion.hotfix > 0 ? ` (hotfix: ${firstVersion.hotfix})` : '';
+      consola.success(`Version: ${versionStr}${hotfixStr}`);
+
+      versions.forEach((pv) => {
+        consola.log(`  ${pv.platform}: ${pv.source}`);
+      });
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/get.ts
+++ b/src/commands/mutate/version/get.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -6,60 +7,54 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Get the version of the app from all relevant files',
   action: async () => {
-    try {
-      const versions = await versionService.getAllVersions();
+    const versions = await versionService.getAllVersions();
 
-      if (versions.length === 0) {
-        consola.error('No platform versions found');
-        process.exit(1);
-      }
-
-      const firstVersion = versions[0]!.version;
-      // Check major.minor.patch synchronization for all platforms
-      const allVersionsInSync = versions.every((pv) => {
-        return (
-          pv.version.major === firstVersion.major &&
-          pv.version.minor === firstVersion.minor &&
-          pv.version.patch === firstVersion.patch
-        );
-      });
-
-      // Check hotfix synchronization between iOS and Android
-      const iosVersion = versions.find((pv) => pv.platform === 'ios');
-      const androidVersion = versions.find((pv) => pv.platform === 'android');
-      let hotfixInSync = true;
-
-      if (iosVersion && androidVersion) {
-        const iosHotfix = iosVersion.version.hotfix || 0;
-        const androidHotfix = androidVersion.version.hotfix || 0;
-        hotfixInSync = iosHotfix === androidHotfix;
-      }
-
-      if (!allVersionsInSync || !hotfixInSync) {
-        consola.error('Versions are not synchronized across platforms:');
-        versions.forEach((pv) => {
-          const versionStr = versionToString(pv.version);
-          const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
-          consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`);
-        });
-        process.exit(1);
-      }
-
-      const versionStr = versionToString(firstVersion);
-      // Show hotfix if iOS or Android has one
-      const platformWithHotfix = versions.find(
-        (pv) => pv.platform !== 'web' && pv.version.hotfix && pv.version.hotfix > 0,
-      );
-      const hotfixStr = platformWithHotfix ? ` (hotfix: ${platformWithHotfix.version.hotfix})` : '';
-
-      consola.success(`Version: ${versionStr}${hotfixStr}`);
-
-      versions.forEach((pv) => {
-        consola.log(`  ${pv.platform}: ${pv.source}`);
-      });
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+    if (versions.length === 0) {
+      throw new CliError('No platform versions found');
     }
+
+    const firstVersion = versions[0]!.version;
+    // Check major.minor.patch synchronization for all platforms
+    const allVersionsInSync = versions.every((pv) => {
+      return (
+        pv.version.major === firstVersion.major &&
+        pv.version.minor === firstVersion.minor &&
+        pv.version.patch === firstVersion.patch
+      );
+    });
+
+    // Check hotfix synchronization between iOS and Android
+    const iosVersion = versions.find((pv) => pv.platform === 'ios');
+    const androidVersion = versions.find((pv) => pv.platform === 'android');
+    let hotfixInSync = true;
+
+    if (iosVersion && androidVersion) {
+      const iosHotfix = iosVersion.version.hotfix || 0;
+      const androidHotfix = androidVersion.version.hotfix || 0;
+      hotfixInSync = iosHotfix === androidHotfix;
+    }
+
+    if (!allVersionsInSync || !hotfixInSync) {
+      consola.error('Versions are not synchronized across platforms:');
+      versions.forEach((pv) => {
+        const versionStr = versionToString(pv.version);
+        const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
+        consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`);
+      });
+      throw new CliError('Versions are not synchronized across platforms');
+    }
+
+    const versionStr = versionToString(firstVersion);
+    // Show hotfix if iOS or Android has one
+    const platformWithHotfix = versions.find(
+      (pv) => pv.platform !== 'web' && pv.version.hotfix && pv.version.hotfix > 0,
+    );
+    const hotfixStr = platformWithHotfix ? ` (hotfix: ${platformWithHotfix.version.hotfix})` : '';
+
+    consola.success(`Version: ${versionStr}${hotfixStr}`);
+
+    versions.forEach((pv) => {
+      consola.log(`  ${pv.platform}: ${pv.source}`);
+    });
   },
 });

--- a/src/commands/mutate/version/get.ts
+++ b/src/commands/mutate/version/get.ts
@@ -15,12 +15,12 @@ export default defineCommand({
       }
 
       const firstVersion = versions[0]!.version;
+      // Check only major.minor.patch synchronization
       const allInSync = versions.every((pv) => {
         return (
           pv.version.major === firstVersion.major &&
           pv.version.minor === firstVersion.minor &&
-          pv.version.patch === firstVersion.patch &&
-          pv.version.hotfix === firstVersion.hotfix
+          pv.version.patch === firstVersion.patch
         );
       });
 
@@ -28,15 +28,13 @@ export default defineCommand({
         consola.error('Versions are not synchronized across platforms:');
         versions.forEach((pv) => {
           const versionStr = versionToString(pv.version);
-          const hotfixStr = pv.version.hotfix > 0 ? ` (hotfix: ${pv.version.hotfix})` : '';
-          consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`);
+          consola.log(`  ${pv.platform}: ${versionStr} (${pv.source})`);
         });
         process.exit(1);
       }
 
       const versionStr = versionToString(firstVersion);
-      const hotfixStr = firstVersion.hotfix > 0 ? ` (hotfix: ${firstVersion.hotfix})` : '';
-      consola.success(`Version: ${versionStr}${hotfixStr}`);
+      consola.success(`Version: ${versionStr}`);
 
       versions.forEach((pv) => {
         consola.log(`  ${pv.platform}: ${pv.source}`);

--- a/src/commands/mutate/version/get.ts
+++ b/src/commands/mutate/version/get.ts
@@ -15,8 +15,8 @@ export default defineCommand({
       }
 
       const firstVersion = versions[0]!.version;
-      // Check only major.minor.patch synchronization
-      const allInSync = versions.every((pv) => {
+      // Check major.minor.patch synchronization for all platforms
+      const allVersionsInSync = versions.every((pv) => {
         return (
           pv.version.major === firstVersion.major &&
           pv.version.minor === firstVersion.minor &&
@@ -24,17 +24,35 @@ export default defineCommand({
         );
       });
 
-      if (!allInSync) {
+      // Check hotfix synchronization between iOS and Android
+      const iosVersion = versions.find((pv) => pv.platform === 'ios');
+      const androidVersion = versions.find((pv) => pv.platform === 'android');
+      let hotfixInSync = true;
+
+      if (iosVersion && androidVersion) {
+        const iosHotfix = iosVersion.version.hotfix || 0;
+        const androidHotfix = androidVersion.version.hotfix || 0;
+        hotfixInSync = iosHotfix === androidHotfix;
+      }
+
+      if (!allVersionsInSync || !hotfixInSync) {
         consola.error('Versions are not synchronized across platforms:');
         versions.forEach((pv) => {
           const versionStr = versionToString(pv.version);
-          consola.log(`  ${pv.platform}: ${versionStr} (${pv.source})`);
+          const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
+          consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`);
         });
         process.exit(1);
       }
 
       const versionStr = versionToString(firstVersion);
-      consola.success(`Version: ${versionStr}`);
+      // Show hotfix if iOS or Android has one
+      const platformWithHotfix = versions.find(
+        (pv) => pv.platform !== 'web' && pv.version.hotfix && pv.version.hotfix > 0,
+      );
+      const hotfixStr = platformWithHotfix ? ` (hotfix: ${platformWithHotfix.version.hotfix})` : '';
+
+      consola.success(`Version: ${versionStr}${hotfixStr}`);
 
       versions.forEach((pv) => {
         consola.log(`  ${pv.platform}: ${pv.source}`);

--- a/src/commands/mutate/version/hotfix.test.ts
+++ b/src/commands/mutate/version/hotfix.test.ts
@@ -1,0 +1,71 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import hotfixCommand from './hotfix.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:hotfix', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should increment hotfix version from 0', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await hotfixCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing hotfix for version 1.2.3 (0 -> 1)...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 3, hotfix: 1 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Hotfix incremented for version 1.2.3 (now 1)');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should increment existing hotfix version', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 5 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await hotfixCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing hotfix for version 1.2.3 (5 -> 6)...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 3, hotfix: 6 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Hotfix incremented for version 1.2.3 (now 6)');
+  });
+
+  it('should handle maximum hotfix version limit', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 99 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+
+    await expect(hotfixCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(hotfixCommand.action({}, undefined)).rejects.toThrow(
+      'Cannot increment hotfix version: would exceed maximum value of 99',
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should handle hotfix sync errors between iOS and Android', async () => {
+    mockVersionService.ensureVersionsInSync.mockRejectedValue(
+      new CliError('Hotfix versions are not synchronized between iOS and Android'),
+    );
+
+    await expect(hotfixCommand.action({}, undefined)).rejects.toThrow(
+      'Hotfix versions are not synchronized between iOS and Android',
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/mutate/version/hotfix.ts
+++ b/src/commands/mutate/version/hotfix.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { incrementHotfix, versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -6,22 +7,23 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Increment the hotfix version of the app in all relevant files',
   action: async () => {
-    try {
-      const currentVersion = await versionService.ensureVersionsInSync();
-      const newVersion = incrementHotfix(currentVersion);
+    const currentVersion = await versionService.ensureVersionsInSync();
 
-      const versionStr = versionToString(currentVersion);
-      const currentHotfix = currentVersion.hotfix || 0;
-      const newHotfix = newVersion.hotfix || 0;
-
-      consola.info(`Incrementing hotfix for version ${versionStr} (${currentHotfix} -> ${newHotfix})...`);
-
-      await versionService.setVersion(newVersion);
-
-      consola.success(`Hotfix incremented for version ${versionStr} (now ${newHotfix})`);
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+    // Check for hotfix version limit
+    const currentHotfix = currentVersion.hotfix || 0;
+    if (currentHotfix >= 99) {
+      throw new CliError('Cannot increment hotfix version: would exceed maximum value of 99');
     }
+
+    const newVersion = incrementHotfix(currentVersion);
+
+    const versionStr = versionToString(currentVersion);
+    const newHotfix = newVersion.hotfix || 0;
+
+    consola.info(`Incrementing hotfix for version ${versionStr} (${currentHotfix} -> ${newHotfix})...`);
+
+    await versionService.setVersion(newVersion);
+
+    consola.success(`Hotfix incremented for version ${versionStr} (now ${newHotfix})`);
   },
 });

--- a/src/commands/mutate/version/hotfix.ts
+++ b/src/commands/mutate/version/hotfix.ts
@@ -1,0 +1,27 @@
+import versionService from '@/services/mutate/version.js';
+import { incrementHotfix, versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Increment the hotfix version of the app in all relevant files',
+  action: async () => {
+    try {
+      const currentVersion = await versionService.ensureVersionsInSync();
+      const newVersion = incrementHotfix(currentVersion);
+
+      const currentVersionStr = versionToString(currentVersion);
+      const newVersionStr = versionToString(newVersion);
+      const hotfixInfo = `(hotfix: ${currentVersion.hotfix} -> ${newVersion.hotfix})`;
+
+      consola.info(`Incrementing hotfix version from ${currentVersionStr} to ${newVersionStr} ${hotfixInfo}...`);
+
+      await versionService.setVersion(newVersion);
+
+      consola.success(`Hotfix version incremented to ${newVersionStr} (hotfix: ${newVersion.hotfix})`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/hotfix.ts
+++ b/src/commands/mutate/version/hotfix.ts
@@ -10,15 +10,13 @@ export default defineCommand({
       const currentVersion = await versionService.ensureVersionsInSync();
       const newVersion = incrementHotfix(currentVersion);
 
-      const currentVersionStr = versionToString(currentVersion);
-      const newVersionStr = versionToString(newVersion);
-      const hotfixInfo = `(hotfix: ${currentVersion.hotfix} -> ${newVersion.hotfix})`;
+      const versionStr = versionToString(currentVersion);
 
-      consola.info(`Incrementing hotfix version from ${currentVersionStr} to ${newVersionStr} ${hotfixInfo}...`);
+      consola.info(`Incrementing hotfix for version ${versionStr}...`);
 
       await versionService.setVersion(newVersion);
 
-      consola.success(`Hotfix version incremented to ${newVersionStr} (hotfix: ${newVersion.hotfix})`);
+      consola.success(`Hotfix incremented for version ${versionStr}`);
     } catch (error) {
       consola.error(error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/src/commands/mutate/version/hotfix.ts
+++ b/src/commands/mutate/version/hotfix.ts
@@ -11,12 +11,14 @@ export default defineCommand({
       const newVersion = incrementHotfix(currentVersion);
 
       const versionStr = versionToString(currentVersion);
+      const currentHotfix = currentVersion.hotfix || 0;
+      const newHotfix = newVersion.hotfix || 0;
 
-      consola.info(`Incrementing hotfix for version ${versionStr}...`);
+      consola.info(`Incrementing hotfix for version ${versionStr} (${currentHotfix} -> ${newHotfix})...`);
 
       await versionService.setVersion(newVersion);
 
-      consola.success(`Hotfix incremented for version ${versionStr}`);
+      consola.success(`Hotfix incremented for version ${versionStr} (now ${newHotfix})`);
     } catch (error) {
       consola.error(error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/src/commands/mutate/version/major.test.ts
+++ b/src/commands/mutate/version/major.test.ts
@@ -1,0 +1,67 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import majorCommand from './major.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:major', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should increment major version successfully', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await majorCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing major version from 1.2.3 to 2.0.0...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 2, minor: 0, patch: 0 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Major version incremented to 2.0.0');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should handle large major versions', async () => {
+    const currentVersion = { major: 999, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await majorCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing major version from 999.2.3 to 1000.0.0...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1000, minor: 0, patch: 0 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Major version incremented to 1000.0.0');
+  });
+
+  it('should handle version sync errors', async () => {
+    mockVersionService.ensureVersionsInSync.mockRejectedValue(
+      new CliError('Versions are not synchronized across platforms'),
+    );
+
+    await expect(majorCommand.action({}, undefined)).rejects.toThrow('Versions are not synchronized across platforms');
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should handle service errors during set', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockRejectedValue(new Error('Failed to update version'));
+
+    await expect(majorCommand.action({}, undefined)).rejects.toThrow('Failed to update version');
+
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 2, minor: 0, patch: 0 });
+  });
+});

--- a/src/commands/mutate/version/major.ts
+++ b/src/commands/mutate/version/major.ts
@@ -1,0 +1,25 @@
+import versionService from '@/services/mutate/version.js';
+import { incrementMajor, versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Increment the major version of the app in all relevant files',
+  action: async () => {
+    try {
+      const currentVersion = await versionService.ensureVersionsInSync();
+      const newVersion = incrementMajor(currentVersion);
+
+      consola.info(
+        `Incrementing major version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+      );
+
+      await versionService.setVersion(newVersion);
+
+      consola.success(`Major version incremented to ${versionToString(newVersion)}`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/major.ts
+++ b/src/commands/mutate/version/major.ts
@@ -6,20 +6,15 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Increment the major version of the app in all relevant files',
   action: async () => {
-    try {
-      const currentVersion = await versionService.ensureVersionsInSync();
-      const newVersion = incrementMajor(currentVersion);
+    const currentVersion = await versionService.ensureVersionsInSync();
+    const newVersion = incrementMajor(currentVersion);
 
-      consola.info(
-        `Incrementing major version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
-      );
+    consola.info(
+      `Incrementing major version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+    );
 
-      await versionService.setVersion(newVersion);
+    await versionService.setVersion(newVersion);
 
-      consola.success(`Major version incremented to ${versionToString(newVersion)}`);
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
-    }
+    consola.success(`Major version incremented to ${versionToString(newVersion)}`);
   },
 });

--- a/src/commands/mutate/version/minor.test.ts
+++ b/src/commands/mutate/version/minor.test.ts
@@ -1,0 +1,68 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import minorCommand from './minor.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:minor', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should increment minor version successfully', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await minorCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing minor version from 1.2.3 to 1.3.0...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 3, patch: 0 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Minor version incremented to 1.3.0');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should handle maximum minor version limit', async () => {
+    const currentVersion = { major: 1, minor: 999, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+
+    await expect(minorCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(minorCommand.action({}, undefined)).rejects.toThrow(
+      'Cannot increment minor version: would exceed maximum value of 999',
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should reset patch and hotfix when incrementing minor', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 5, hotfix: 3 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await minorCommand.action({}, undefined);
+
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 3, patch: 0 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Minor version incremented to 1.3.0');
+  });
+
+  it('should handle version sync errors', async () => {
+    mockVersionService.ensureVersionsInSync.mockRejectedValue(
+      new CliError('Versions are not synchronized across platforms'),
+    );
+
+    await expect(minorCommand.action({}, undefined)).rejects.toThrow('Versions are not synchronized across platforms');
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/mutate/version/minor.ts
+++ b/src/commands/mutate/version/minor.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { incrementMinor, versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -6,20 +7,21 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Increment the minor version of the app in all relevant files',
   action: async () => {
-    try {
-      const currentVersion = await versionService.ensureVersionsInSync();
-      const newVersion = incrementMinor(currentVersion);
+    const currentVersion = await versionService.ensureVersionsInSync();
 
-      consola.info(
-        `Incrementing minor version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
-      );
-
-      await versionService.setVersion(newVersion);
-
-      consola.success(`Minor version incremented to ${versionToString(newVersion)}`);
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+    // Check for minor version limit
+    if (currentVersion.minor >= 999) {
+      throw new CliError('Cannot increment minor version: would exceed maximum value of 999');
     }
+
+    const newVersion = incrementMinor(currentVersion);
+
+    consola.info(
+      `Incrementing minor version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+    );
+
+    await versionService.setVersion(newVersion);
+
+    consola.success(`Minor version incremented to ${versionToString(newVersion)}`);
   },
 });

--- a/src/commands/mutate/version/minor.ts
+++ b/src/commands/mutate/version/minor.ts
@@ -1,0 +1,25 @@
+import versionService from '@/services/mutate/version.js';
+import { incrementMinor, versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Increment the minor version of the app in all relevant files',
+  action: async () => {
+    try {
+      const currentVersion = await versionService.ensureVersionsInSync();
+      const newVersion = incrementMinor(currentVersion);
+
+      consola.info(
+        `Incrementing minor version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+      );
+
+      await versionService.setVersion(newVersion);
+
+      consola.success(`Minor version incremented to ${versionToString(newVersion)}`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/patch.test.ts
+++ b/src/commands/mutate/version/patch.test.ts
@@ -1,0 +1,68 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import patchCommand from './patch.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:patch', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should increment patch version successfully', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await patchCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Incrementing patch version from 1.2.3 to 1.2.4...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 4 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Patch version incremented to 1.2.4');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should handle maximum patch version limit', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 99, hotfix: 0 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+
+    await expect(patchCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(patchCommand.action({}, undefined)).rejects.toThrow(
+      'Cannot increment patch version: would exceed maximum value of 99',
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should reset hotfix when incrementing patch', async () => {
+    const currentVersion = { major: 1, minor: 2, patch: 3, hotfix: 5 };
+    mockVersionService.ensureVersionsInSync.mockResolvedValue(currentVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await patchCommand.action({}, undefined);
+
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 4 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Patch version incremented to 1.2.4');
+  });
+
+  it('should handle version sync errors', async () => {
+    mockVersionService.ensureVersionsInSync.mockRejectedValue(
+      new CliError('Versions are not synchronized across platforms'),
+    );
+
+    await expect(patchCommand.action({}, undefined)).rejects.toThrow('Versions are not synchronized across platforms');
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/mutate/version/patch.ts
+++ b/src/commands/mutate/version/patch.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { incrementPatch, versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -6,20 +7,21 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Increment the patch version of the app in all relevant files',
   action: async () => {
-    try {
-      const currentVersion = await versionService.ensureVersionsInSync();
-      const newVersion = incrementPatch(currentVersion);
+    const currentVersion = await versionService.ensureVersionsInSync();
 
-      consola.info(
-        `Incrementing patch version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
-      );
-
-      await versionService.setVersion(newVersion);
-
-      consola.success(`Patch version incremented to ${versionToString(newVersion)}`);
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+    // Check for patch version limit
+    if (currentVersion.patch >= 99) {
+      throw new CliError('Cannot increment patch version: would exceed maximum value of 99');
     }
+
+    const newVersion = incrementPatch(currentVersion);
+
+    consola.info(
+      `Incrementing patch version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+    );
+
+    await versionService.setVersion(newVersion);
+
+    consola.success(`Patch version incremented to ${versionToString(newVersion)}`);
   },
 });

--- a/src/commands/mutate/version/patch.ts
+++ b/src/commands/mutate/version/patch.ts
@@ -1,0 +1,25 @@
+import versionService from '@/services/mutate/version.js';
+import { incrementPatch, versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Increment the patch version of the app in all relevant files',
+  action: async () => {
+    try {
+      const currentVersion = await versionService.ensureVersionsInSync();
+      const newVersion = incrementPatch(currentVersion);
+
+      consola.info(
+        `Incrementing patch version from ${versionToString(currentVersion)} to ${versionToString(newVersion)}...`,
+      );
+
+      await versionService.setVersion(newVersion);
+
+      consola.success(`Patch version incremented to ${versionToString(newVersion)}`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/set.test.ts
+++ b/src/commands/mutate/version/set.test.ts
@@ -1,0 +1,59 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import setCommand from './set.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:set', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should set a valid version', async () => {
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await setCommand.action({}, ['1.2.3']);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Setting version to 1.2.3...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 3 });
+    expect(mockConsola.success).toHaveBeenCalledWith('Version set to 1.2.3');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should handle invalid version format', async () => {
+    await expect(setCommand.action({}, ['1.2'])).rejects.toThrow(CliError);
+    await expect(setCommand.action({}, ['1.2'])).rejects.toThrow(
+      "Invalid version format. Please use the format 'major.minor.patch' (e.g. '1.2.3').",
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should handle non-numeric version parts', async () => {
+    await expect(setCommand.action({}, ['1.2.abc'])).rejects.toThrow(CliError);
+    await expect(setCommand.action({}, ['1.2.abc'])).rejects.toThrow(
+      "Invalid version format. Please use the format 'major.minor.patch' (e.g. '1.2.3').",
+    );
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should handle service errors', async () => {
+    mockVersionService.setVersion.mockRejectedValue(new Error('Failed to set version'));
+
+    await expect(setCommand.action({}, ['1.2.3'])).rejects.toThrow('Failed to set version');
+
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith({ major: 1, minor: 2, patch: 3 });
+  });
+});

--- a/src/commands/mutate/version/set.ts
+++ b/src/commands/mutate/version/set.ts
@@ -1,0 +1,24 @@
+import versionService from '@/services/mutate/version.js';
+import { parseVersion, versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Set the version of the app in all relevant files',
+  args: z.tuple([z.string().describe('Version')]),
+  action: async (_options, args) => {
+    try {
+      const version = parseVersion(args[0]);
+
+      consola.info(`Setting version to ${versionToString(version)}...`);
+
+      await versionService.setVersion(version);
+
+      consola.success(`Version set to ${versionToString(version)}`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/set.ts
+++ b/src/commands/mutate/version/set.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { parseVersion, versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -8,17 +9,17 @@ export default defineCommand({
   description: 'Set the version of the app in all relevant files',
   args: z.tuple([z.string().describe('Version')]),
   action: async (_options, args) => {
+    let version;
     try {
-      const version = parseVersion(args[0]);
-
-      consola.info(`Setting version to ${versionToString(version)}...`);
-
-      await versionService.setVersion(version);
-
-      consola.success(`Version set to ${versionToString(version)}`);
+      version = parseVersion(args[0]);
     } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+      throw new CliError("Invalid version format. Please use the format 'major.minor.patch' (e.g. '1.2.3').");
     }
+
+    consola.info(`Setting version to ${versionToString(version)}...`);
+
+    await versionService.setVersion(version);
+
+    consola.success(`Version set to ${versionToString(version)}`);
   },
 });

--- a/src/commands/mutate/version/sync.test.ts
+++ b/src/commands/mutate/version/sync.test.ts
@@ -1,0 +1,108 @@
+import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import syncCommand from './sync.js';
+
+vi.mock('consola');
+vi.mock('@/services/mutate/version.js');
+
+describe('mutate:version:sync', () => {
+  const mockConsola = vi.mocked(consola);
+  const mockVersionService = vi.mocked(versionService);
+  const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should sync to highest version across platforms', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 0 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+      {
+        platform: 'android' as const,
+        version: { major: 1, minor: 3, patch: 0, hotfix: 0 },
+        source: 'android/app/build.gradle',
+      },
+      { platform: 'web' as const, version: { major: 1, minor: 2, patch: 4 }, source: 'package.json' },
+    ];
+    const highestVersion = { major: 1, minor: 3, patch: 0, hotfix: 0 };
+
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+    mockVersionService.getHighestVersion.mockResolvedValue(highestVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await syncCommand.action({}, undefined);
+
+    expect(mockConsola.info).toHaveBeenCalledWith('Current versions:');
+    expect(mockConsola.log).toHaveBeenCalledWith('  ios: 1.2.3');
+    expect(mockConsola.log).toHaveBeenCalledWith('  android: 1.3.0');
+    expect(mockConsola.log).toHaveBeenCalledWith('  web: 1.2.4');
+    expect(mockConsola.info).toHaveBeenCalledWith('Syncing all platforms to highest version: 1.3.0...');
+    expect(mockVersionService.setVersion).toHaveBeenCalledWith(highestVersion);
+    expect(mockConsola.success).toHaveBeenCalledWith('All platforms synced to version 1.3.0');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('should sync including hotfix for iOS/Android', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 5 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+      {
+        platform: 'android' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 5 },
+        source: 'android/app/build.gradle',
+      },
+      { platform: 'web' as const, version: { major: 1, minor: 2, patch: 2 }, source: 'package.json' },
+    ];
+    const highestVersion = { major: 1, minor: 2, patch: 3, hotfix: 5 };
+
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+    mockVersionService.getHighestVersion.mockResolvedValue(highestVersion);
+    mockVersionService.setVersion.mockResolvedValue(undefined);
+
+    await syncCommand.action({}, undefined);
+
+    expect(mockConsola.log).toHaveBeenCalledWith('  ios: 1.2.3 (hotfix: 5)');
+    expect(mockConsola.log).toHaveBeenCalledWith('  android: 1.2.3 (hotfix: 5)');
+    expect(mockConsola.log).toHaveBeenCalledWith('  web: 1.2.2');
+    expect(mockConsola.info).toHaveBeenCalledWith('Syncing all platforms to highest version: 1.2.3 (hotfix: 5)...');
+    expect(mockConsola.success).toHaveBeenCalledWith('All platforms synced to version 1.2.3 (hotfix: 5)');
+  });
+
+  it('should handle no platform versions found', async () => {
+    mockVersionService.getAllVersions.mockResolvedValue([]);
+
+    await expect(syncCommand.action({}, undefined)).rejects.toThrow(CliError);
+    await expect(syncCommand.action({}, undefined)).rejects.toThrow('No platform versions found');
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+
+  it('should handle service errors', async () => {
+    const mockVersions = [
+      {
+        platform: 'ios' as const,
+        version: { major: 1, minor: 2, patch: 3, hotfix: 0 },
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      },
+    ];
+    mockVersionService.getAllVersions.mockResolvedValue(mockVersions);
+    mockVersionService.getHighestVersion.mockRejectedValue(new Error('Failed to determine highest version'));
+
+    await expect(syncCommand.action({}, undefined)).rejects.toThrow('Failed to determine highest version');
+
+    expect(mockVersionService.setVersion).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/mutate/version/sync.ts
+++ b/src/commands/mutate/version/sync.ts
@@ -1,0 +1,39 @@
+import versionService from '@/services/mutate/version.js';
+import { versionToString } from '@/utils/version.js';
+import { defineCommand } from '@robingenz/zli';
+import consola from 'consola';
+
+export default defineCommand({
+  description: 'Set the highest version number among all platforms in all relevant files',
+  action: async () => {
+    try {
+      const versions = await versionService.getAllVersions();
+
+      if (versions.length === 0) {
+        consola.error('No platform versions found');
+        process.exit(1);
+      }
+
+      const highestVersion = await versionService.getHighestVersion();
+
+      consola.info('Current versions:');
+      versions.forEach((pv) => {
+        const versionStr = versionToString(pv.version);
+        const hotfixStr = pv.version.hotfix > 0 ? ` (hotfix: ${pv.version.hotfix})` : '';
+        consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr}`);
+      });
+
+      const highestVersionStr = versionToString(highestVersion);
+      const hotfixStr = highestVersion.hotfix > 0 ? ` (hotfix: ${highestVersion.hotfix})` : '';
+
+      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}${hotfixStr}...`);
+
+      await versionService.setVersion(highestVersion);
+
+      consola.success(`All platforms synced to version ${highestVersionStr}${hotfixStr}`);
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/mutate/version/sync.ts
+++ b/src/commands/mutate/version/sync.ts
@@ -1,4 +1,5 @@
 import versionService from '@/services/mutate/version.js';
+import { CliError } from '@/utils/error.js';
 import { versionToString } from '@/utils/version.js';
 import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
@@ -6,34 +7,28 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Set the highest version number among all platforms in all relevant files',
   action: async () => {
-    try {
-      const versions = await versionService.getAllVersions();
+    const versions = await versionService.getAllVersions();
 
-      if (versions.length === 0) {
-        consola.error('No platform versions found');
-        process.exit(1);
-      }
-
-      const highestVersion = await versionService.getHighestVersion();
-
-      consola.info('Current versions:');
-      versions.forEach((pv) => {
-        const versionStr = versionToString(pv.version);
-        const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
-        consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr}`);
-      });
-
-      const highestVersionStr = versionToString(highestVersion);
-      const hotfixStr = highestVersion.hotfix ? ` (hotfix: ${highestVersion.hotfix})` : '';
-
-      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}${hotfixStr}...`);
-
-      await versionService.setVersion(highestVersion);
-
-      consola.success(`All platforms synced to version ${highestVersionStr}${hotfixStr}`);
-    } catch (error) {
-      consola.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
+    if (versions.length === 0) {
+      throw new CliError('No platform versions found');
     }
+
+    const highestVersion = await versionService.getHighestVersion();
+
+    consola.info('Current versions:');
+    versions.forEach((pv) => {
+      const versionStr = versionToString(pv.version);
+      const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
+      consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr}`);
+    });
+
+    const highestVersionStr = versionToString(highestVersion);
+    const hotfixStr = highestVersion.hotfix ? ` (hotfix: ${highestVersion.hotfix})` : '';
+
+    consola.info(`Syncing all platforms to highest version: ${highestVersionStr}${hotfixStr}...`);
+
+    await versionService.setVersion(highestVersion);
+
+    consola.success(`All platforms synced to version ${highestVersionStr}${hotfixStr}`);
   },
 });

--- a/src/commands/mutate/version/sync.ts
+++ b/src/commands/mutate/version/sync.ts
@@ -19,16 +19,18 @@ export default defineCommand({
       consola.info('Current versions:');
       versions.forEach((pv) => {
         const versionStr = versionToString(pv.version);
-        consola.log(`  ${pv.platform}: ${versionStr}`);
+        const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
+        consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr}`);
       });
 
       const highestVersionStr = versionToString(highestVersion);
+      const hotfixStr = highestVersion.hotfix ? ` (hotfix: ${highestVersion.hotfix})` : '';
 
-      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}...`);
+      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}${hotfixStr}...`);
 
       await versionService.setVersion(highestVersion);
 
-      consola.success(`All platforms synced to version ${highestVersionStr}`);
+      consola.success(`All platforms synced to version ${highestVersionStr}${hotfixStr}`);
     } catch (error) {
       consola.error(error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/src/commands/mutate/version/sync.ts
+++ b/src/commands/mutate/version/sync.ts
@@ -19,18 +19,16 @@ export default defineCommand({
       consola.info('Current versions:');
       versions.forEach((pv) => {
         const versionStr = versionToString(pv.version);
-        const hotfixStr = pv.version.hotfix > 0 ? ` (hotfix: ${pv.version.hotfix})` : '';
-        consola.log(`  ${pv.platform}: ${versionStr}${hotfixStr}`);
+        consola.log(`  ${pv.platform}: ${versionStr}`);
       });
 
       const highestVersionStr = versionToString(highestVersion);
-      const hotfixStr = highestVersion.hotfix > 0 ? ` (hotfix: ${highestVersion.hotfix})` : '';
 
-      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}${hotfixStr}...`);
+      consola.info(`Syncing all platforms to highest version: ${highestVersionStr}...`);
 
       await versionService.setVersion(highestVersion);
 
-      consola.success(`All platforms synced to version ${highestVersionStr}${hotfixStr}`);
+      consola.success(`All platforms synced to version ${highestVersionStr}`);
     } catch (error) {
       consola.error(error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,13 @@ const config = defineConfig({
     'apps:channels:update': await import('@/commands/apps/channels/update.js').then((mod) => mod.default),
     'apps:devices:delete': await import('@/commands/apps/devices/delete.js').then((mod) => mod.default),
     'manifests:generate': await import('@/commands/manifests/generate.js').then((mod) => mod.default),
+    'mutate:version:get': await import('@/commands/mutate/version/get.js').then((mod) => mod.default),
+    'mutate:version:set': await import('@/commands/mutate/version/set.js').then((mod) => mod.default),
+    'mutate:version:major': await import('@/commands/mutate/version/major.js').then((mod) => mod.default),
+    'mutate:version:minor': await import('@/commands/mutate/version/minor.js').then((mod) => mod.default),
+    'mutate:version:patch': await import('@/commands/mutate/version/patch.js').then((mod) => mod.default),
+    'mutate:version:hotfix': await import('@/commands/mutate/version/hotfix.js').then((mod) => mod.default),
+    'mutate:version:sync': await import('@/commands/mutate/version/sync.js').then((mod) => mod.default),
     'organizations:create': await import('@/commands/organizations/create.js').then((mod) => mod.default),
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 import configService from '@/services/config.js';
 import updateService from '@/services/update.js';
-import { getMessageFromUnknownError } from '@/utils/error.js';
+import { CliError, getMessageFromUnknownError } from '@/utils/error.js';
 import { defineConfig, processConfig, ZliError } from '@robingenz/zli';
 import * as Sentry from '@sentry/node';
 import { AxiosError } from 'axios';
 import consola from 'consola';
-import { ZodError } from 'zod';
 import { createRequire } from 'module';
+import { ZodError } from 'zod';
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 
@@ -46,8 +46,11 @@ const config = defineConfig({
 });
 
 const captureException = async (error: unknown) => {
-  // Ignore errors from the CLI itself (e.g. "No command found.")
+  // Ignore expected CLI errors (e.g. "No command found.")
   if (error instanceof ZliError) {
+    return;
+  }
+  if (error instanceof CliError) {
     return;
   }
   // Ignore validation errors

--- a/src/services/mutate/version.ts
+++ b/src/services/mutate/version.ts
@@ -1,3 +1,4 @@
+import { CliError } from '@/utils/error.js';
 import {
   Version,
   compareVersions,
@@ -209,7 +210,7 @@ export class VersionService {
 
     const firstVersion = versions && versions[0] ? versions[0].version : null;
     if (!firstVersion) {
-      throw new Error('No platform versions found');
+      throw new CliError('No platform versions found');
     }
 
     // Check major.minor.patch synchronization for all platforms
@@ -226,7 +227,7 @@ export class VersionService {
         const hotfixStr = pv.platform !== 'web' && pv.version.hotfix ? ` (hotfix: ${pv.version.hotfix})` : '';
         return `${pv.platform}: ${versionStr}${hotfixStr} (${pv.source})`;
       });
-      throw new Error(`Versions are not synchronized across platforms:\n${versionStrings.join('\n')}`);
+      throw new CliError(`Versions are not synchronized across platforms:\n${versionStrings.join('\n')}`);
     }
 
     // Check hotfix synchronization between iOS and Android only
@@ -238,7 +239,7 @@ export class VersionService {
       const androidHotfix = androidVersion.version.hotfix || 0;
 
       if (iosHotfix !== androidHotfix) {
-        throw new Error(
+        throw new CliError(
           `Hotfix versions are not synchronized between iOS and Android:\n` +
             `iOS: ${versionToString(iosVersion.version)} (hotfix: ${iosHotfix})\n` +
             `Android: ${versionToString(androidVersion.version)} (hotfix: ${androidHotfix})`,
@@ -257,7 +258,7 @@ export class VersionService {
     const versions = await this.getAllVersions();
 
     if (versions.length === 0) {
-      throw new Error('No platform versions found');
+      throw new CliError('No platform versions found');
     }
 
     let highest = versions[0]!;

--- a/src/services/mutate/version.ts
+++ b/src/services/mutate/version.ts
@@ -6,9 +6,16 @@ import {
   versionToBuildNumber,
   versionToString,
 } from '@/utils/version.js';
-import { MobileProject } from '@trapezedev/project';
+import { MobileProject, Logger } from '@trapezedev/project';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+
+// Disable Trapeze logging
+Logger.log = () => {};
+Logger.v = () => {};
+Logger.debug = () => {};
+Logger.warn = () => {};
+Logger.error = () => {};
 
 export interface PlatformVersion {
   platform: 'ios' | 'android' | 'web';

--- a/src/services/mutate/version.ts
+++ b/src/services/mutate/version.ts
@@ -1,0 +1,233 @@
+import { MobileProject } from '@trapezedev/project';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  Version,
+  compareVersions,
+  parseBuildNumber,
+  parseVersion,
+  versionToBuildNumber,
+  versionToString,
+  versionsEqual,
+} from '@/utils/version.js';
+
+export interface PlatformVersion {
+  platform: 'ios' | 'android' | 'web';
+  version: Version;
+  source: string;
+}
+
+export class VersionService {
+  private projectPath: string;
+
+  constructor(projectPath: string = process.cwd()) {
+    this.projectPath = projectPath;
+  }
+
+  async getAllVersions(): Promise<PlatformVersion[]> {
+    const versions: PlatformVersion[] = [];
+
+    const iosVersion = await this.getIosVersion();
+    if (iosVersion) {
+      versions.push(iosVersion);
+    }
+
+    const androidVersion = await this.getAndroidVersion();
+    if (androidVersion) {
+      versions.push(androidVersion);
+    }
+
+    const webVersion = await this.getWebVersion();
+    if (webVersion) {
+      versions.push(webVersion);
+    }
+
+    return versions;
+  }
+
+  async getIosVersion(): Promise<PlatformVersion | null> {
+    const iosPath = join(this.projectPath, 'ios');
+    if (!existsSync(iosPath)) {
+      return null;
+    }
+
+    try {
+      const project = new MobileProject(this.projectPath, {
+        ios: {
+          path: 'ios/App',
+        },
+      });
+      await project.load();
+
+      if (!project.ios) {
+        return null;
+      }
+
+      const iosProject = await project.ios.getPbxProject();
+      if (!iosProject) {
+        return null;
+      }
+
+      const buildNumber = await project.ios.getBuild(null, null);
+      if (!buildNumber) {
+        return null;
+      }
+
+      const version = parseBuildNumber(buildNumber);
+      return {
+        platform: 'ios',
+        version,
+        source: 'ios/App/App.xcodeproj/project.pbxproj',
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async getAndroidVersion(): Promise<PlatformVersion | null> {
+    const androidPath = join(this.projectPath, 'android');
+    if (!existsSync(androidPath)) {
+      return null;
+    }
+
+    try {
+      const project = new MobileProject(this.projectPath, {
+        android: {
+          path: 'android',
+        },
+      });
+      await project.load();
+
+      if (!project.android) {
+        return null;
+      }
+
+      const versionCode = await project.android.getVersionCode();
+      if (!versionCode) {
+        return null;
+      }
+
+      const version = parseBuildNumber(versionCode);
+      return {
+        platform: 'android',
+        version,
+        source: 'android/app/build.gradle',
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async getWebVersion(): Promise<PlatformVersion | null> {
+    const packageJsonPath = join(this.projectPath, 'package.json');
+    if (!existsSync(packageJsonPath)) {
+      return null;
+    }
+
+    try {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      if (!packageJson.version) {
+        return null;
+      }
+
+      const version = parseVersion(packageJson.version);
+      return {
+        platform: 'web',
+        version,
+        source: 'package.json',
+      };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async setVersion(version: Version): Promise<void> {
+    const iosPath = join(this.projectPath, 'ios');
+    const androidPath = join(this.projectPath, 'android');
+    const packageJsonPath = join(this.projectPath, 'package.json');
+
+    const project = new MobileProject(this.projectPath, {
+      ios: existsSync(iosPath)
+        ? {
+            path: 'ios/App',
+          }
+        : undefined,
+      android: existsSync(androidPath)
+        ? {
+            path: 'android',
+          }
+        : undefined,
+    });
+
+    await project.load();
+
+    const versionString = versionToString(version);
+    const buildNumber = versionToBuildNumber(version);
+
+    if (project.ios) {
+      await project.ios.setVersion(null, null, versionString);
+      await project.ios.setBuild(null, null, buildNumber.toString());
+
+      const infoPlistPath = await project.ios.getInfoPlist(null, null);
+      if (infoPlistPath) {
+        const infoPlist = await project.ios.getPlistFile(infoPlistPath);
+        if (infoPlist) {
+          await infoPlist.set({
+            CFBundleShortVersionString: versionString,
+            CFBundleVersion: buildNumber.toString(),
+          });
+        }
+      }
+    }
+
+    if (project.android) {
+      await project.android.setVersionName(versionString);
+      await project.android.setVersionCode(buildNumber);
+    }
+
+    if (existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      packageJson.version = versionString;
+      const fs = await import('fs/promises');
+      await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+    }
+
+    await project.commit();
+  }
+
+  async ensureVersionsInSync(): Promise<Version> {
+    const versions = await this.getAllVersions();
+
+    if (versions.length === 0) {
+      throw new Error('No platform versions found');
+    }
+
+    const firstVersion = versions[0]!.version;
+    const allInSync = versions.every((pv) => versionsEqual(pv.version, firstVersion));
+
+    if (!allInSync) {
+      const versionStrings = versions.map((pv) => `${pv.platform}: ${versionToString(pv.version)} (${pv.source})`);
+      throw new Error(`Versions are not synchronized across platforms:\n${versionStrings.join('\n')}`);
+    }
+
+    return firstVersion;
+  }
+
+  async getHighestVersion(): Promise<Version> {
+    const versions = await this.getAllVersions();
+
+    if (versions.length === 0) {
+      throw new Error('No platform versions found');
+    }
+
+    let highest = versions[0]!;
+    for (const current of versions) {
+      if (compareVersions(current.version, highest.version) > 0) {
+        highest = current;
+      }
+    }
+    return highest.version;
+  }
+}
+
+export default new VersionService();

--- a/src/utils/error.test.ts
+++ b/src/utils/error.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { CliError, getMessageFromUnknownError } from './error.js';
+
+describe('CliError', () => {
+  it('should be an instance of Error', () => {
+    const error = new CliError('Test error');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(CliError);
+  });
+
+  it('should have the correct name', () => {
+    const error = new CliError('Test error');
+    expect(error.name).toBe('CliError');
+  });
+
+  it('should have the correct message', () => {
+    const message = 'This is a test error message';
+    const error = new CliError(message);
+    expect(error.message).toBe(message);
+  });
+});
+
+describe('getMessageFromUnknownError', () => {
+  it('should handle CliError correctly', () => {
+    const message = 'This is a CLI error';
+    const error = new CliError(message);
+    expect(getMessageFromUnknownError(error)).toBe(message);
+  });
+
+  it('should handle regular Error', () => {
+    const message = 'This is a regular error';
+    const error = new Error(message);
+    expect(getMessageFromUnknownError(error)).toBe(message);
+  });
+
+  it('should handle unknown error types', () => {
+    expect(getMessageFromUnknownError('string error')).toBe('An unknown error has occurred.');
+    expect(getMessageFromUnknownError(123)).toBe('An unknown error has occurred.');
+    expect(getMessageFromUnknownError(null)).toBe('An unknown error has occurred.');
+    expect(getMessageFromUnknownError(undefined)).toBe('An unknown error has occurred.');
+  });
+});

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,9 +1,18 @@
 import { AxiosError } from 'axios';
 import { ZodError } from 'zod';
 
+export class CliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
 export const getMessageFromUnknownError = (error: unknown): string => {
   let message = 'An unknown error has occurred.';
-  if (error instanceof AxiosError) {
+  if (error instanceof CliError) {
+    message = error.message;
+  } else if (error instanceof AxiosError) {
     message = getErrorMessageFromAxiosError(error);
   } else if (error instanceof ZodError) {
     message = getErrorMessageFromZodError(error);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,111 @@
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+  hotfix: number;
+}
+
+export const parseVersion = (versionString: string): Version => {
+  const parts = versionString.split('.');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid version format: ${versionString}. Expected format: major.minor.patch`);
+  }
+
+  const major = parseInt(parts[0] || '0', 10);
+  const minor = parseInt(parts[1] || '0', 10);
+  const patch = parseInt(parts[2] || '0', 10);
+
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+    throw new Error(`Invalid version format: ${versionString}. Version parts must be numbers.`);
+  }
+
+  if (major < 0 || minor < 0 || patch < 0) {
+    throw new Error(`Invalid version format: ${versionString}. Version parts must be non-negative.`);
+  }
+
+  return { major, minor, patch, hotfix: 0 };
+};
+
+export const parseBuildNumber = (buildNumber: string | number): Version => {
+  const buildStr = buildNumber.toString();
+
+  // Build number format: [major][minor:3][patch:2][hotfix:2]
+  // The last 7 digits are always minor(3) + patch(2) + hotfix(2)
+  if (buildStr.length < 8) {
+    throw new Error(`Invalid build number: ${buildNumber}. Build number must be at least 8 digits.`);
+  }
+
+  const fixedPartStart = buildStr.length - 7;
+  const major = parseInt(buildStr.substring(0, fixedPartStart), 10);
+  const minor = parseInt(buildStr.substring(fixedPartStart, fixedPartStart + 3), 10);
+  const patch = parseInt(buildStr.substring(fixedPartStart + 3, fixedPartStart + 5), 10);
+  const hotfix = parseInt(buildStr.substring(fixedPartStart + 5, fixedPartStart + 7), 10);
+
+  return { major, minor, patch, hotfix };
+};
+
+export const versionToString = (version: Version): string => {
+  return `${version.major}.${version.minor}.${version.patch}`;
+};
+
+export const versionToBuildNumber = (version: Version): number => {
+  // Build number format: [major][minor:3][patch:2][hotfix:2]
+  // Major version has no limit and uses as many digits as needed
+  const majorStr = version.major.toString();
+  const minor = version.minor.toString().padStart(3, '0');
+  const patch = version.patch.toString().padStart(2, '0');
+  const hotfix = version.hotfix.toString().padStart(2, '0');
+
+  if (version.minor > 999) {
+    throw new Error(`Minor version ${version.minor} exceeds maximum value of 999`);
+  }
+  if (version.patch > 99) {
+    throw new Error(`Patch version ${version.patch} exceeds maximum value of 99`);
+  }
+  if (version.hotfix > 99) {
+    throw new Error(`Hotfix version ${version.hotfix} exceeds maximum value of 99`);
+  }
+
+  return parseInt(`${majorStr}${minor}${patch}${hotfix}`, 10);
+};
+
+export const incrementMajor = (version: Version): Version => {
+  const newMajor = version.major + 1;
+  return { major: newMajor, minor: 0, patch: 0, hotfix: 0 };
+};
+
+export const incrementMinor = (version: Version): Version => {
+  const newMinor = version.minor + 1;
+  if (newMinor > 999) {
+    throw new Error(`Cannot increment minor version: would exceed maximum value of 999`);
+  }
+  return { ...version, minor: newMinor, patch: 0, hotfix: 0 };
+};
+
+export const incrementPatch = (version: Version): Version => {
+  const newPatch = version.patch + 1;
+  if (newPatch > 99) {
+    throw new Error(`Cannot increment patch version: would exceed maximum value of 99`);
+  }
+  return { ...version, patch: newPatch, hotfix: 0 };
+};
+
+export const incrementHotfix = (version: Version): Version => {
+  const newHotfix = version.hotfix + 1;
+  if (newHotfix > 99) {
+    throw new Error(`Cannot increment hotfix version: would exceed maximum value of 99`);
+  }
+  return { ...version, hotfix: newHotfix };
+};
+
+export const compareVersions = (v1: Version, v2: Version): number => {
+  if (v1.major !== v2.major) return v1.major - v2.major;
+  if (v1.minor !== v2.minor) return v1.minor - v2.minor;
+  if (v1.patch !== v2.patch) return v1.patch - v2.patch;
+  if (v1.hotfix !== v2.hotfix) return v1.hotfix - v2.hotfix;
+  return 0;
+};
+
+export const versionsEqual = (v1: Version, v2: Version): boolean => {
+  return compareVersions(v1, v2) === 0;
+};


### PR DESCRIPTION
### PR moved to a separate CLI, see https://github.com/capawesome-team/capver

---

The following new commands have been added:
- `mutate:version:get`: Gets the version of the app. 
- `mutate:version:set`: Sets the version of the app in all relevant files.
- `mutate:version:major`: Increments the major version of the app in all relevant files.
- `mutate:version:minor`: Increments the minor version of the app in all relevant files.
- `mutate:version:patch`: Increments the patch version of the app in all relevant files.
- `mutate:version:hotfix`: Increments the hotfix version of the app in all relevant files.
- `mutate:version:sync`: Sets the highest version number among all platforms in all relevant files.

All commands (except `mutate:version:sync`) will throw an error if the version is not synchronized across all platforms.

Development version for testing:

```
npm i @capawesome/cli@2.1.4-dev.6aa4113.1756747592
```