### PR TITLE
fix(apps): validate file count before zipping in `apps:builds:create`

### DIFF
--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -1,6 +1,9 @@
+import { UserError } from '@/utils/error.js';
 import AdmZip from 'adm-zip';
 import { globby } from 'globby';
 import path from 'path';
+
+const MAX_ZIP_ENTRIES = 65535;
 
 interface Zip {
   zipFolder(sourceFolder: string): Promise<Buffer>;
@@ -22,6 +25,12 @@ class ZipImpl implements Zip {
       ignore: ['.git/**'],
       dot: true,
     });
+    if (files.length > MAX_ZIP_ENTRIES) {
+      throw new UserError(
+        `The source folder contains ${files.length} files, which exceeds the ZIP limit of ${MAX_ZIP_ENTRIES} entries. ` +
+          `Make sure your .gitignore excludes large directories such as node_modules.`,
+      );
+    }
     const zip = new AdmZip();
     for (const file of files) {
       const filePath = path.join(sourceFolder, file);


### PR DESCRIPTION
## Summary

When `apps:builds:create --path` was given a folder containing more than 65,535 files (e.g. one where `node_modules` was not gitignored), `adm-zip` crashed deep inside `writeUInt16LE` with an opaque `RangeError`, since the standard ZIP format stores the entry count in a uint16 field.

This adds a pre-check in `zipFolderWithGitignore` that throws a `UserError` with an actionable message before attempting to build the archive. Because `UserError` is filtered out in the global error handler, the user now sees a clear message and the error is no longer reported to Sentry.

## Test plan

- [ ] Run `apps:builds:create --path <folder>` against a folder with more than 65,535 files and verify the new error message is shown.
- [ ] Run `apps:builds:create --path <folder>` against a normal folder and verify zipping still succeeds.