### PR TITLE
fix: validate file existence before reading in `apps:certificates:create` and `apps:destinations:create`

### DIFF
--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -141,7 +141,7 @@ export default defineCommand({
 
     const fileExists = await fileExistsAtPath(file);
     if (!fileExists) {
-      consola.error('The certificate file does not exist.');
+      consola.error(`The certificate file was not found or is not accessible: ${file}`);
       process.exit(1);
     }
     const buffer = fs.readFileSync(file);
@@ -153,7 +153,7 @@ export default defineCommand({
       for (const profilePath of provisioningProfile) {
         const profileExists = await fileExistsAtPath(profilePath);
         if (!profileExists) {
-          consola.error('The provisioning profile file does not exist.');
+          consola.error(`The provisioning profile file was not found or is not accessible: ${profilePath}`);
           process.exit(1);
         }
         const profileBuffer = fs.readFileSync(profilePath);

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -2,6 +2,7 @@ import appCertificatesService from '@/services/app-certificates.js';
 import appProvisioningProfilesService from '@/services/app-provisioning-profiles.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
+import { fileExistsAtPath } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -138,6 +139,11 @@ export default defineCommand({
       }
     }
 
+    const fileExists = await fileExistsAtPath(file);
+    if (!fileExists) {
+      consola.error('The certificate file does not exist.');
+      process.exit(1);
+    }
     const buffer = fs.readFileSync(file);
     const fileName = path.basename(file);
 
@@ -145,6 +151,11 @@ export default defineCommand({
     const provisioningProfileIds: string[] = [];
     if (provisioningProfile && provisioningProfile.length > 0) {
       for (const profilePath of provisioningProfile) {
+        const profileExists = await fileExistsAtPath(profilePath);
+        if (!profileExists) {
+          consola.error('The provisioning profile file does not exist.');
+          process.exit(1);
+        }
         const profileBuffer = fs.readFileSync(profilePath);
         const profileFileName = path.basename(profilePath);
         const profile = await appProvisioningProfilesService.create({

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -180,7 +180,7 @@ export default defineCommand({
       // Upload Google service account key file
       const googleServiceAccountKeyFileExists = await fileExistsAtPath(googleServiceAccountKeyFile);
       if (!googleServiceAccountKeyFileExists) {
-        consola.error('The Google service account key file does not exist.');
+        consola.error(`The Google service account key file was not found or is not accessible: ${googleServiceAccountKeyFile}`);
         process.exit(1);
       }
       const buffer = fs.readFileSync(googleServiceAccountKeyFile);
@@ -238,7 +238,7 @@ export default defineCommand({
         // Upload Apple API key file
         const appleApiKeyFileExists = await fileExistsAtPath(appleApiKeyFile);
         if (!appleApiKeyFileExists) {
-          consola.error('The Apple API key file does not exist.');
+          consola.error(`The Apple API key file was not found or is not accessible: ${appleApiKeyFile}`);
           process.exit(1);
         }
         const buffer = fs.readFileSync(appleApiKeyFile);

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -180,7 +180,9 @@ export default defineCommand({
       // Upload Google service account key file
       const googleServiceAccountKeyFileExists = await fileExistsAtPath(googleServiceAccountKeyFile);
       if (!googleServiceAccountKeyFileExists) {
-        consola.error(`The Google service account key file was not found or is not accessible: ${googleServiceAccountKeyFile}`);
+        consola.error(
+          `The Google service account key file was not found or is not accessible: ${googleServiceAccountKeyFile}`,
+        );
         process.exit(1);
       }
       const buffer = fs.readFileSync(googleServiceAccountKeyFile);

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -3,6 +3,7 @@ import appDestinationsService from '@/services/app-destinations.js';
 import appGoogleServiceAccountKeysService from '@/services/app-google-service-account-keys.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
+import { fileExistsAtPath } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -177,6 +178,11 @@ export default defineCommand({
         }
       }
       // Upload Google service account key file
+      const googleServiceAccountKeyFileExists = await fileExistsAtPath(googleServiceAccountKeyFile);
+      if (!googleServiceAccountKeyFileExists) {
+        consola.error('The Google service account key file does not exist.');
+        process.exit(1);
+      }
       const buffer = fs.readFileSync(googleServiceAccountKeyFile);
       const fileName = path.basename(googleServiceAccountKeyFile);
       const key = await appGoogleServiceAccountKeysService.create({
@@ -230,6 +236,11 @@ export default defineCommand({
           }
         }
         // Upload Apple API key file
+        const appleApiKeyFileExists = await fileExistsAtPath(appleApiKeyFile);
+        if (!appleApiKeyFileExists) {
+          consola.error('The Apple API key file does not exist.');
+          process.exit(1);
+        }
         const buffer = fs.readFileSync(appleApiKeyFile);
         const fileName = path.basename(appleApiKeyFile);
         const key = await appAppleApiKeysService.create({


### PR DESCRIPTION
## Summary

- Add `fileExistsAtPath` checks before `fs.readFileSync` calls in `apps:certificates:create` (certificate file and provisioning profile) and `apps:destinations:create` (Google service account key file and Apple API key file).
- Show descriptive error messages instead of crashing with raw `ENOENT` errors.