### PR TITLE
fix: validate file existence before reading user-provided files

### DIFF
--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -7,6 +7,7 @@ import { AppBuildArtifactDto } from '@/types/app-build.js';
 import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
+import { fileExistsAtPath } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -270,6 +271,11 @@ export default defineCommand({
     // Parse ad hoc environment variables from inline and file
     const variablesMap = new Map<string, string>();
     if (options.variableFile) {
+      const fileExists = await fileExistsAtPath(options.variableFile);
+      if (!fileExists) {
+        consola.error(`The variable file was not found or is not accessible: ${options.variableFile}`);
+        process.exit(1);
+      }
       const fileContent = await fs.readFile(options.variableFile, 'utf-8');
       const fileVariables = parseKeyValuePairs(fileContent);
       fileVariables.forEach((v) => variablesMap.set(v.key, v.value));

--- a/src/commands/apps/environments/set.ts
+++ b/src/commands/apps/environments/set.ts
@@ -2,6 +2,7 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
+import { fileExistsAtPath } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -58,6 +59,11 @@ export default defineCommand({
     // Parse variables from inline and file
     const variablesMap = new Map<string, string>();
     if (variableFile) {
+      const fileExists = await fileExistsAtPath(variableFile);
+      if (!fileExists) {
+        consola.error(`The variable file was not found or is not accessible: ${variableFile}`);
+        process.exit(1);
+      }
       const fileContent = await fs.promises.readFile(variableFile, 'utf-8');
       const fileVariables = parseKeyValuePairs(fileContent);
       fileVariables.forEach((v) => variablesMap.set(v.key, v.value));
@@ -71,6 +77,11 @@ export default defineCommand({
     // Parse secrets from inline and file
     const secretsMap = new Map<string, string>();
     if (secretFile) {
+      const fileExists = await fileExistsAtPath(secretFile);
+      if (!fileExists) {
+        consola.error(`The secret file was not found or is not accessible: ${secretFile}`);
+        process.exit(1);
+      }
       const fileContent = await fs.promises.readFile(secretFile, 'utf-8');
       const fileSecrets = parseKeyValuePairs(fileContent);
       fileSecrets.forEach((s) => secretsMap.set(s.key, s.value));

--- a/src/commands/apps/liveupdates/create.ts
+++ b/src/commands/apps/liveupdates/create.ts
@@ -8,6 +8,7 @@ import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { parseCustomProperties } from '@/utils/custom-properties.js';
 import { isInteractive } from '@/utils/environment.js';
+import { fileExistsAtPath } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -200,6 +201,11 @@ export default defineCommand({
     // Parse ad hoc environment variables from inline and file
     const variablesMap = new Map<string, string>();
     if (options.variableFile) {
+      const fileExists = await fileExistsAtPath(options.variableFile);
+      if (!fileExists) {
+        consola.error(`The variable file was not found or is not accessible: ${options.variableFile}`);
+        process.exit(1);
+      }
       const fileContent = await fs.readFile(options.variableFile, 'utf-8');
       const fileVariables = parseKeyValuePairs(fileContent);
       fileVariables.forEach((v) => variablesMap.set(v.key, v.value));


### PR DESCRIPTION
## Summary
- Validate user-provided file paths exist before reading them, mirroring the pattern introduced in #151.
- Replaces raw `ENOENT` crashes (reported via Sentry) with friendly `consola.error` messages and a clean exit.
- Fixes cover:
  - `apps:builds:create` — `--variable-file`
  - `apps:liveupdates:create` — `--variable-file`
  - `apps:environments:set` — `--variable-file` and `--secret-file`

## Test plan
- [ ] Run each affected command with a non-existent file path (e.g. `--variable-file ./does-not-exist`) and confirm a friendly error is shown and the process exits with code 1.
- [ ] Run each affected command with a valid file and confirm variables/secrets are parsed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)