### PR TITLE
fix: surface actionable error when config file is not writable

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -8,6 +8,13 @@ export class UserError extends Error {
   }
 }
 
+export const getCodeFromUnknownError = (error: unknown): string | undefined => {
+  if (error instanceof Error && 'code' in error && typeof error.code === 'string') {
+    return error.code;
+  }
+  return undefined;
+};
+
 export const getMessageFromUnknownError = (error: unknown): string => {
   let message = 'An unknown error has occurred.';
   if (error instanceof AxiosError) {

--- a/src/utils/user-config.test.ts
+++ b/src/utils/user-config.test.ts
@@ -1,0 +1,93 @@
+import { readUser, writeUser } from 'rc9';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserError } from './error.js';
+import userConfig from './user-config.js';
+
+vi.mock('rc9');
+
+describe('userConfig', () => {
+  const mockReadUser = vi.mocked(readUser);
+  const mockWriteUser = vi.mocked(writeUser);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createFsError = (code: string, path: string): Error => Object.assign(new Error(code), { code, path });
+
+  describe('read', () => {
+    it('should return the config on success', () => {
+      mockReadUser.mockReturnValue({ token: 'abc' });
+      expect(userConfig.read()).toEqual({ token: 'abc' });
+    });
+
+    it('should throw UserError on EACCES with the failing path in the message', () => {
+      const error = createFsError('EACCES', '/home/user/.capawesome');
+      mockReadUser.mockImplementation(() => {
+        throw error;
+      });
+      expect(() => userConfig.read()).toThrow(UserError);
+      expect(() => userConfig.read()).toThrow(/\/home\/user\/\.capawesome/);
+    });
+
+    it('should throw UserError on EPERM', () => {
+      const error = createFsError('EPERM', '/home/user/.capawesome');
+      mockReadUser.mockImplementation(() => {
+        throw error;
+      });
+      expect(() => userConfig.read()).toThrow(UserError);
+    });
+
+    it('should rethrow non-access errors as-is', () => {
+      const error = new Error('something else');
+      mockReadUser.mockImplementation(() => {
+        throw error;
+      });
+      let caught: unknown;
+      try {
+        userConfig.read();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBe(error);
+    });
+  });
+
+  describe('write', () => {
+    it('should call writeUser on success', () => {
+      userConfig.write({ token: 'abc' });
+      expect(mockWriteUser).toHaveBeenCalledWith({ token: 'abc' }, { name: '.capawesome' });
+    });
+
+    it('should throw UserError on EACCES with the failing path in the message', () => {
+      const error = createFsError('EACCES', '/home/user/.capawesome');
+      mockWriteUser.mockImplementation(() => {
+        throw error;
+      });
+      expect(() => userConfig.write({})).toThrow(UserError);
+      expect(() => userConfig.write({})).toThrow(/\/home\/user\/\.capawesome/);
+    });
+
+    it('should throw UserError on EPERM', () => {
+      const error = createFsError('EPERM', '/home/user/.capawesome');
+      mockWriteUser.mockImplementation(() => {
+        throw error;
+      });
+      expect(() => userConfig.write({})).toThrow(UserError);
+    });
+
+    it('should rethrow non-access errors as-is', () => {
+      const error = new Error('something else');
+      mockWriteUser.mockImplementation(() => {
+        throw error;
+      });
+      let caught: unknown;
+      try {
+        userConfig.write({});
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBe(error);
+    });
+  });
+});

--- a/src/utils/user-config.test.ts
+++ b/src/utils/user-config.test.ts
@@ -1,3 +1,5 @@
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { readUser, writeUser } from 'rc9';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { UserError } from './error.js';
@@ -36,6 +38,15 @@ describe('userConfig', () => {
         throw error;
       });
       expect(() => userConfig.read()).toThrow(UserError);
+    });
+
+    it('should fall back to the resolved home path when the error has no path', () => {
+      const error = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      mockReadUser.mockImplementation(() => {
+        throw error;
+      });
+      const expectedPath = resolve(process.env.XDG_CONFIG_HOME || homedir(), '.capawesome');
+      expect(() => userConfig.read()).toThrow(expectedPath);
     });
 
     it('should rethrow non-access errors as-is', () => {

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -17,7 +17,7 @@ class UserConfigImpl implements UserConfig {
     try {
       return readUser<IUserConfig>({ name: this.file });
     } catch (error) {
-      throw this.toUserErrorIfAccessDenied(error);
+      this.rethrow(error);
     }
   }
 
@@ -25,19 +25,20 @@ class UserConfigImpl implements UserConfig {
     try {
       writeUser<IUserConfig>(config, { name: this.file });
     } catch (error) {
-      throw this.toUserErrorIfAccessDenied(error);
+      this.rethrow(error);
     }
   }
 
-  private toUserErrorIfAccessDenied(error: unknown): unknown {
-    if (getCodeFromUnknownError(error) === 'EACCES') {
+  private rethrow(error: unknown): never {
+    const code = getCodeFromUnknownError(error);
+    if (code === 'EACCES' || code === 'EPERM') {
       const path = error instanceof Error && 'path' in error && typeof error.path === 'string' ? error.path : this.file;
-      return new UserError(
+      throw new UserError(
         `Permission denied accessing ${path}. The file may be owned by another user (e.g. from a previous run with sudo). ` +
           `Try running \`sudo chown $USER ${path}\` or \`rm ${path}\`, then retry.`,
       );
     }
-    return error;
+    throw error;
   }
 }
 

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -1,3 +1,4 @@
+import { getCodeFromUnknownError, UserError } from '@/utils/error.js';
 import { readUser, writeUser } from 'rc9';
 
 export interface IUserConfig {
@@ -13,11 +14,30 @@ class UserConfigImpl implements UserConfig {
   private file = '.capawesome';
 
   read(): IUserConfig {
-    return readUser<IUserConfig>({ name: this.file });
+    try {
+      return readUser<IUserConfig>({ name: this.file });
+    } catch (error) {
+      throw this.toUserErrorIfAccessDenied(error);
+    }
   }
 
   write(config: IUserConfig): void {
-    writeUser<IUserConfig>(config, { name: this.file });
+    try {
+      writeUser<IUserConfig>(config, { name: this.file });
+    } catch (error) {
+      throw this.toUserErrorIfAccessDenied(error);
+    }
+  }
+
+  private toUserErrorIfAccessDenied(error: unknown): unknown {
+    if (getCodeFromUnknownError(error) === 'EACCES') {
+      const path = error instanceof Error && 'path' in error && typeof error.path === 'string' ? error.path : this.file;
+      return new UserError(
+        `Permission denied accessing ${path}. The file may be owned by another user (e.g. from a previous run with sudo). ` +
+          `Try running \`sudo chown $USER ${path}\` or \`rm ${path}\`, then retry.`,
+      );
+    }
+    return error;
   }
 }
 

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -1,4 +1,6 @@
 import { getCodeFromUnknownError, UserError } from '@/utils/error.js';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { readUser, writeUser } from 'rc9';
 
 export interface IUserConfig {
@@ -32,13 +34,20 @@ class UserConfigImpl implements UserConfig {
   private rethrow(error: unknown): never {
     const code = getCodeFromUnknownError(error);
     if (code === 'EACCES' || code === 'EPERM') {
-      const path = error instanceof Error && 'path' in error && typeof error.path === 'string' ? error.path : this.file;
+      const path =
+        error instanceof Error && 'path' in error && typeof error.path === 'string'
+          ? error.path
+          : this.getResolvedPath();
       throw new UserError(
         `Permission denied accessing ${path}. The file may be owned by another user (e.g. from a previous run with sudo). ` +
           `Try running \`sudo chown $USER ${path}\` or \`rm ${path}\`, then retry.`,
       );
     }
     throw error;
+  }
+
+  private getResolvedPath(): string {
+    return resolve(process.env.XDG_CONFIG_HOME || homedir(), this.file);
   }
 }
 


### PR DESCRIPTION
## Summary

- When the CLI cannot read or write `~/.capawesome` because of OS permissions (e.g. the file was created during a previous `sudo` run and is now owned by `root`), it threw a raw `EACCES` that bubbled up to Sentry with no guidance for the user.
- `UserConfigImpl.read` / `write` now catch the failure and re-throw a `UserError` carrying the resolved path and a suggested remediation (`chown` or `rm`). `UserError` is already filtered out of Sentry reporting in `src/index.ts`, so these environment issues stop polluting the issue tracker.
- Added `getCodeFromUnknownError` in `src/utils/error.ts` to extract `code` from unknown errors in a type-safe way, and used it for the `EACCES` check.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/commands/login.test.ts src/commands/logout.test.ts src/commands/whoami.test.ts`
- [x] `npm run fmt`