### PR TITLE
feat(apps): add `--type` option to `apps:create`

### DIFF
--- a/src/commands/apps/create.test.ts
+++ b/src/commands/apps/create.test.ts
@@ -46,10 +46,10 @@ describe('apps-create', () => {
     const appId = 'app-456';
     const testToken = 'test-token';
 
-    const options = { name: appName, organizationId };
+    const options = { name: appName, organizationId, type: 'capacitor' as const };
 
     const scope = nock(DEFAULT_API_BASE_URL)
-      .post(`/v1/apps?organizationId=${organizationId}`, { name: appName })
+      .post(`/v1/apps?organizationId=${organizationId}`, { name: appName, type: 'capacitor' })
       .matchHeader('Authorization', `Bearer ${testToken}`)
       .reply(201, { id: appId, name: appName });
 
@@ -66,10 +66,10 @@ describe('apps-create', () => {
     const appId = 'app-456';
     const testToken = 'test-token';
 
-    const options = { name: appName };
+    const options = { name: appName, type: 'capacitor' as const };
 
     const createScope = nock(DEFAULT_API_BASE_URL)
-      .post(`/v1/apps?organizationId=${orgId}`, { name: appName })
+      .post(`/v1/apps?organizationId=${orgId}`, { name: appName, type: 'capacitor' })
       .matchHeader('Authorization', `Bearer ${testToken}`)
       .reply(201, { id: appId, name: appName });
 
@@ -88,10 +88,10 @@ describe('apps-create', () => {
     const appId = 'app-456';
     const testToken = 'test-token';
 
-    const options = { organizationId };
+    const options = { organizationId, type: 'capacitor' as const };
 
     const scope = nock(DEFAULT_API_BASE_URL)
-      .post(`/v1/apps?organizationId=${organizationId}`, { name: promptedAppName })
+      .post(`/v1/apps?organizationId=${organizationId}`, { name: promptedAppName, type: 'capacitor' })
       .matchHeader('Authorization', `Bearer ${testToken}`)
       .reply(201, { id: appId, name: promptedAppName });
 
@@ -104,7 +104,7 @@ describe('apps-create', () => {
   });
 
   it('should exit when promptOrganizationSelection exits', async () => {
-    const options = { name: 'Test App' };
+    const options = { name: 'Test App', type: 'capacitor' as const };
 
     mockPromptOrganizationSelection.mockImplementation(() => {
       process.exit(1);
@@ -119,10 +119,10 @@ describe('apps-create', () => {
     const organizationId = 'org-123';
     const testToken = 'test-token';
 
-    const options = { name: appName, organizationId };
+    const options = { name: appName, organizationId, type: 'capacitor' as const };
 
     const scope = nock(DEFAULT_API_BASE_URL)
-      .post(`/v1/apps?organizationId=${organizationId}`, { name: appName })
+      .post(`/v1/apps?organizationId=${organizationId}`, { name: appName, type: 'capacitor' })
       .matchHeader('Authorization', `Bearer ${testToken}`)
       .reply(400, { message: 'App name already exists' });
 

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -15,12 +15,17 @@ export default defineCommand({
       link: z.boolean().optional().describe('Connect the created app to the local git repository.'),
       name: z.string().optional().describe('Name of the app.'),
       organizationId: z.string().optional().describe('ID of the organization to create the app in.'),
+      type: z
+        .enum(['android', 'capacitor', 'cordova', 'ios'])
+        .optional()
+        .describe('Type of the app. Defaults to `capacitor`.'),
       yes: z.boolean().optional().describe('Skip all confirmation prompts.'),
     }),
     { y: 'yes' },
   ),
   action: withAuth(async (options, args) => {
     let { json, name, organizationId } = options;
+    const type = options.type ?? 'capacitor';
 
     if (!organizationId) {
       if (!isInteractive()) {
@@ -36,7 +41,7 @@ export default defineCommand({
       }
       name = await prompt('Enter the name of the app:', { type: 'text' });
     }
-    const response = await appsService.create({ name, organizationId });
+    const response = await appsService.create({ name, organizationId, type });
     if (!json) {
       consola.info(`App ID: ${response.id}`);
       consola.info(`App URL: ${DEFAULT_CONSOLE_BASE_URL}/apps/${response.id}`);

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -3,9 +3,12 @@ export interface AppDto {
   name: string;
 }
 
+export type AppType = 'android' | 'capacitor' | 'cordova' | 'ios';
+
 export interface CreateAppDto {
   name: string;
   organizationId: string;
+  type: AppType;
 }
 
 export interface DeleteAppDto {


### PR DESCRIPTION
## Summary

Adds a new optional `--type` flag to the `apps:create` command so users can create non-Capacitor apps on Capawesome Cloud.

- Supported values: `android`, `capacitor`, `cordova`, `ios` (alphabetical).
- Defaults to `capacitor` to preserve existing behavior.
- The default is applied inside the action (rather than via Zod's `.default()`) so the option remains structurally optional for the programmatic call site in `src/utils/prompt.ts`.

## Changes

- `src/types/app.ts` — new `AppType` union; added `type: AppType` on `CreateAppDto`.
- `src/commands/apps/create.ts` — new `--type` option; default applied via `options.type ?? 'capacitor'`.
- `src/commands/apps/create.test.ts` — updated assertions to include `type` in request body.

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npx vitest run` — all 157 tests pass.
- [x] `npm run fmt` — clean.
- [ ] Manual: `apps:create` without `--type` still creates a Capacitor app.
- [ ] Manual: `apps:create --type cordova` / `--type android` / `--type ios` round-trips through the API.