### PR TITLE
fix: check file read access to surface permission errors

### DIFF
--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -7,7 +7,7 @@ import { AppBuildArtifactDto } from '@/types/app-build.js';
 import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -271,9 +271,9 @@ export default defineCommand({
     // Parse ad hoc environment variables from inline and file
     const variablesMap = new Map<string, string>();
     if (options.variableFile) {
-      const fileExists = await fileExistsAtPath(options.variableFile);
-      if (!fileExists) {
-        consola.error(`The variable file was not found or is not accessible: ${options.variableFile}`);
+      const variableFileReadable = await isReadable(options.variableFile);
+      if (!variableFileReadable) {
+        consola.error(`The variable file does not exist or is not accessible: ${options.variableFile}`);
         process.exit(1);
       }
       const fileContent = await fs.readFile(options.variableFile, 'utf-8');

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -2,7 +2,7 @@ import appCertificatesService from '@/services/app-certificates.js';
 import appProvisioningProfilesService from '@/services/app-provisioning-profiles.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -139,9 +139,9 @@ export default defineCommand({
       }
     }
 
-    const fileExists = await fileExistsAtPath(file);
-    if (!fileExists) {
-      consola.error(`The certificate file was not found or is not accessible: ${file}`);
+    const fileReadable = await isReadable(file);
+    if (!fileReadable) {
+      consola.error(`The certificate file does not exist or is not accessible: ${file}`);
       process.exit(1);
     }
     const buffer = fs.readFileSync(file);
@@ -151,9 +151,9 @@ export default defineCommand({
     const provisioningProfileIds: string[] = [];
     if (provisioningProfile && provisioningProfile.length > 0) {
       for (const profilePath of provisioningProfile) {
-        const profileExists = await fileExistsAtPath(profilePath);
-        if (!profileExists) {
-          consola.error(`The provisioning profile file was not found or is not accessible: ${profilePath}`);
+        const profileReadable = await isReadable(profilePath);
+        if (!profileReadable) {
+          consola.error(`The provisioning profile file does not exist or is not accessible: ${profilePath}`);
           process.exit(1);
         }
         const profileBuffer = fs.readFileSync(profilePath);

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -3,7 +3,7 @@ import appDestinationsService from '@/services/app-destinations.js';
 import appGoogleServiceAccountKeysService from '@/services/app-google-service-account-keys.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -178,10 +178,10 @@ export default defineCommand({
         }
       }
       // Upload Google service account key file
-      const googleServiceAccountKeyFileExists = await fileExistsAtPath(googleServiceAccountKeyFile);
-      if (!googleServiceAccountKeyFileExists) {
+      const googleServiceAccountKeyFileReadable = await isReadable(googleServiceAccountKeyFile);
+      if (!googleServiceAccountKeyFileReadable) {
         consola.error(
-          `The Google service account key file was not found or is not accessible: ${googleServiceAccountKeyFile}`,
+          `The Google service account key file does not exist or is not accessible: ${googleServiceAccountKeyFile}`,
         );
         process.exit(1);
       }
@@ -238,9 +238,9 @@ export default defineCommand({
           }
         }
         // Upload Apple API key file
-        const appleApiKeyFileExists = await fileExistsAtPath(appleApiKeyFile);
-        if (!appleApiKeyFileExists) {
-          consola.error(`The Apple API key file was not found or is not accessible: ${appleApiKeyFile}`);
+        const appleApiKeyFileReadable = await isReadable(appleApiKeyFile);
+        if (!appleApiKeyFileReadable) {
+          consola.error(`The Apple API key file does not exist or is not accessible: ${appleApiKeyFile}`);
           process.exit(1);
         }
         const buffer = fs.readFileSync(appleApiKeyFile);

--- a/src/commands/apps/environments/set.ts
+++ b/src/commands/apps/environments/set.ts
@@ -2,7 +2,7 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
@@ -59,9 +59,9 @@ export default defineCommand({
     // Parse variables from inline and file
     const variablesMap = new Map<string, string>();
     if (variableFile) {
-      const fileExists = await fileExistsAtPath(variableFile);
-      if (!fileExists) {
-        consola.error(`The variable file was not found or is not accessible: ${variableFile}`);
+      const variableFileReadable = await isReadable(variableFile);
+      if (!variableFileReadable) {
+        consola.error(`The variable file does not exist or is not accessible: ${variableFile}`);
         process.exit(1);
       }
       const fileContent = await fs.promises.readFile(variableFile, 'utf-8');
@@ -77,9 +77,9 @@ export default defineCommand({
     // Parse secrets from inline and file
     const secretsMap = new Map<string, string>();
     if (secretFile) {
-      const fileExists = await fileExistsAtPath(secretFile);
-      if (!fileExists) {
-        consola.error(`The secret file was not found or is not accessible: ${secretFile}`);
+      const secretFileReadable = await isReadable(secretFile);
+      if (!secretFileReadable) {
+        consola.error(`The secret file does not exist or is not accessible: ${secretFile}`);
         process.exit(1);
       }
       const fileContent = await fs.promises.readFile(secretFile, 'utf-8');

--- a/src/commands/apps/liveupdates/bundle.ts
+++ b/src/commands/apps/liveupdates/bundle.ts
@@ -1,5 +1,5 @@
 import { isInteractive } from '@/utils/environment.js';
-import { directoryContainsSourceMaps, directoryContainsSymlinks, fileExistsAtPath, isDirectory } from '@/utils/file.js';
+import { directoryContainsSourceMaps, directoryContainsSymlinks, isReadable, isDirectory } from '@/utils/file.js';
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -50,9 +50,9 @@ export default defineCommand({
     inputPath = pathModule.resolve(inputPath);
 
     // Validate input path exists
-    const inputExists = await fileExistsAtPath(inputPath);
-    if (!inputExists) {
-      consola.error(`Input path does not exist: ${inputPath}`);
+    const inputPathReadable = await isReadable(inputPath);
+    if (!inputPathReadable) {
+      consola.error(`The input path does not exist or is not accessible: ${inputPath}`);
       process.exit(1);
     }
 
@@ -65,9 +65,9 @@ export default defineCommand({
 
     // Validate directory contains index.html
     const indexHtmlPath = pathModule.join(inputPath, 'index.html');
-    const hasIndexHtml = await fileExistsAtPath(indexHtmlPath);
-    if (!hasIndexHtml) {
-      consola.error(`Directory must contain an index.html file: ${inputPath}`);
+    const indexHtmlReadable = await isReadable(indexHtmlPath);
+    if (!indexHtmlReadable) {
+      consola.error(`The index.html file does not exist or is not accessible: ${indexHtmlPath}`);
       process.exit(1);
     }
 
@@ -91,8 +91,8 @@ export default defineCommand({
     outputPath = pathModule.resolve(outputPath);
 
     // 3. Check if output exists and handle overwrite
-    const outputExists = await fileExistsAtPath(outputPath);
-    if (outputExists) {
+    const outputPathReadable = await isReadable(outputPath);
+    if (outputPathReadable) {
       if (!overwrite) {
         if (!isInteractive()) {
           consola.error(
@@ -113,9 +113,9 @@ export default defineCommand({
 
     // Validate parent directory exists
     const outputDir = pathModule.dirname(outputPath);
-    const outputDirExists = await fileExistsAtPath(outputDir);
-    if (!outputDirExists) {
-      consola.error(`Output directory does not exist: ${outputDir}`);
+    const outputDirReadable = await isReadable(outputDir);
+    if (!outputDirReadable) {
+      consola.error(`The output directory does not exist or is not accessible: ${outputDir}`);
       process.exit(1);
     }
 

--- a/src/commands/apps/liveupdates/bundle.ts
+++ b/src/commands/apps/liveupdates/bundle.ts
@@ -1,5 +1,11 @@
 import { isInteractive } from '@/utils/environment.js';
-import { directoryContainsSourceMaps, directoryContainsSymlinks, isReadable, isDirectory } from '@/utils/file.js';
+import {
+  directoryContainsSourceMaps,
+  directoryContainsSymlinks,
+  isDirectory,
+  isReadable,
+  pathExists,
+} from '@/utils/file.js';
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -91,8 +97,8 @@ export default defineCommand({
     outputPath = pathModule.resolve(outputPath);
 
     // 3. Check if output exists and handle overwrite
-    const outputPathReadable = await isReadable(outputPath);
-    if (outputPathReadable) {
+    const outputPathExists = await pathExists(outputPath);
+    if (outputPathExists) {
       if (!overwrite) {
         if (!isInteractive()) {
           consola.error(
@@ -113,9 +119,9 @@ export default defineCommand({
 
     // Validate parent directory exists
     const outputDir = pathModule.dirname(outputPath);
-    const outputDirReadable = await isReadable(outputDir);
-    if (!outputDirReadable) {
-      consola.error(`The output directory does not exist or is not accessible: ${outputDir}`);
+    const outputDirExists = await pathExists(outputDir);
+    if (!outputDirExists) {
+      consola.error(`The output directory does not exist: ${outputDir}`);
       process.exit(1);
     }
 

--- a/src/commands/apps/liveupdates/create.ts
+++ b/src/commands/apps/liveupdates/create.ts
@@ -8,7 +8,7 @@ import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { parseCustomProperties } from '@/utils/custom-properties.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
@@ -201,9 +201,9 @@ export default defineCommand({
     // Parse ad hoc environment variables from inline and file
     const variablesMap = new Map<string, string>();
     if (options.variableFile) {
-      const fileExists = await fileExistsAtPath(options.variableFile);
-      if (!fileExists) {
-        consola.error(`The variable file was not found or is not accessible: ${options.variableFile}`);
+      const variableFileReadable = await isReadable(options.variableFile);
+      if (!variableFileReadable) {
+        consola.error(`The variable file does not exist or is not accessible: ${options.variableFile}`);
         process.exit(1);
       }
       const fileContent = await fs.readFile(options.variableFile, 'utf-8');

--- a/src/commands/apps/liveupdates/generate-manifest.test.ts
+++ b/src/commands/apps/liveupdates/generate-manifest.test.ts
@@ -1,4 +1,4 @@
-import { directoryContainsSymlinks, fileExistsAtPath, isDirectory } from '@/utils/file.js';
+import { directoryContainsSymlinks, isReadable, isDirectory } from '@/utils/file.js';
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
 import consola from 'consola';
@@ -15,7 +15,7 @@ vi.mock('@/utils/environment.js', () => ({
 }));
 
 describe('apps-liveupdates-generatemanifest', () => {
-  const mockFileExistsAtPath = vi.mocked(fileExistsAtPath);
+  const mockIsReadable = vi.mocked(isReadable);
   const mockIsDirectory = vi.mocked(isDirectory);
   const mockDirectoryContainsSymlinks = vi.mocked(directoryContainsSymlinks);
   const mockGenerateManifestJson = vi.mocked(generateManifestJson);
@@ -37,13 +37,13 @@ describe('apps-liveupdates-generatemanifest', () => {
   it('should generate manifest with provided path', async () => {
     const options = { path: './dist' };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockGenerateManifestJson.mockResolvedValue(undefined);
 
     await generateManifestCommand.action(options, undefined);
 
-    expect(mockFileExistsAtPath).toHaveBeenCalledWith('./dist');
+    expect(mockIsReadable).toHaveBeenCalledWith('./dist');
     expect(mockGenerateManifestJson).toHaveBeenCalledWith('./dist');
     expect(mockConsola.success).toHaveBeenCalledWith('Manifest file generated.');
   });
@@ -52,7 +52,7 @@ describe('apps-liveupdates-generatemanifest', () => {
     const options = {};
 
     mockPrompt.mockResolvedValueOnce('./www');
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockGenerateManifestJson.mockResolvedValue(undefined);
 
@@ -61,7 +61,7 @@ describe('apps-liveupdates-generatemanifest', () => {
     expect(mockPrompt).toHaveBeenCalledWith('Enter the path to the web assets folder (e.g., `dist` or `www`):', {
       type: 'text',
     });
-    expect(mockFileExistsAtPath).toHaveBeenCalledWith('./www');
+    expect(mockIsReadable).toHaveBeenCalledWith('./www');
     expect(mockGenerateManifestJson).toHaveBeenCalledWith('./www');
     expect(mockConsola.success).toHaveBeenCalledWith('Manifest file generated.');
   });
@@ -79,17 +79,17 @@ describe('apps-liveupdates-generatemanifest', () => {
   it('should handle nonexistent path', async () => {
     const options = { path: './nonexistent' };
 
-    mockFileExistsAtPath.mockResolvedValue(false);
+    mockIsReadable.mockResolvedValue(false);
 
     await expect(generateManifestCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
 
-    expect(mockConsola.error).toHaveBeenCalledWith('The path does not exist.');
+    expect(mockConsola.error).toHaveBeenCalledWith('The path does not exist or is not accessible: ./nonexistent');
   });
 
   it('should handle non-directory path', async () => {
     const options = { path: './file.txt' };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(false);
 
     await expect(generateManifestCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
@@ -100,7 +100,7 @@ describe('apps-liveupdates-generatemanifest', () => {
   it('should warn when symlinks are detected', async () => {
     const options = { path: './dist' };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockDirectoryContainsSymlinks.mockResolvedValue(true);
     mockGenerateManifestJson.mockResolvedValue(undefined);

--- a/src/commands/apps/liveupdates/generate-manifest.ts
+++ b/src/commands/apps/liveupdates/generate-manifest.ts
@@ -1,5 +1,5 @@
 import { isInteractive } from '@/utils/environment.js';
-import { directoryContainsSourceMaps, directoryContainsSymlinks, fileExistsAtPath, isDirectory } from '@/utils/file.js';
+import { directoryContainsSourceMaps, directoryContainsSymlinks, isReadable, isDirectory } from '@/utils/file.js';
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
@@ -34,9 +34,9 @@ export default defineCommand({
     }
 
     // Check if the path exists
-    const pathExists = await fileExistsAtPath(path);
-    if (!pathExists) {
-      consola.error(`The path does not exist.`);
+    const pathReadable = await isReadable(path);
+    if (!pathReadable) {
+      consola.error(`The path does not exist or is not accessible: ${path}`);
       process.exit(1);
     }
     // Check if the path is a directory

--- a/src/commands/apps/liveupdates/register.test.ts
+++ b/src/commands/apps/liveupdates/register.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
 import authorizationService from '@/services/authorization-service.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import userConfig from '@/utils/user-config.js';
 import consola from 'consola';
 import nock from 'nock';
@@ -22,7 +22,7 @@ vi.mock('consola');
 describe('apps-liveupdates-register', () => {
   const mockUserConfig = vi.mocked(userConfig);
   const mockAuthorizationService = vi.mocked(authorizationService);
-  const mockFileExistsAtPath = vi.mocked(fileExistsAtPath);
+  const mockIsReadable = vi.mocked(isReadable);
   const mockConsola = vi.mocked(consola);
 
   beforeEach(() => {
@@ -148,7 +148,7 @@ describe('apps-liveupdates-register', () => {
       yes: true,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
 
     // Mock utility functions
     const mockZip = await import('@/utils/zip.js');
@@ -203,7 +203,7 @@ describe('apps-liveupdates-register', () => {
       yes: true,
     };
 
-    mockFileExistsAtPath.mockImplementation((path: string) => {
+    mockIsReadable.mockImplementation((path: string) => {
       if (path === privateKeyPath) return Promise.resolve(true);
       if (path === bundlePath) return Promise.resolve(true);
       return Promise.resolve(false);
@@ -270,7 +270,7 @@ describe('apps-liveupdates-register', () => {
       yes: true,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
 
     // Mock utility functions
     const mockZip = await import('@/utils/zip.js');
@@ -326,7 +326,7 @@ describe('apps-liveupdates-register', () => {
       rolloutPercentage: 1,
     };
 
-    mockFileExistsAtPath.mockImplementation((path: string) => {
+    mockIsReadable.mockImplementation((path: string) => {
       if (path === privateKeyPath) return Promise.resolve(false);
       return Promise.resolve(true);
     });
@@ -339,7 +339,9 @@ describe('apps-liveupdates-register', () => {
 
     await expect(registerCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
 
-    expect(mockConsola.error).toHaveBeenCalledWith('Private key file not found.');
+    expect(mockConsola.error).toHaveBeenCalledWith(
+      `The private key file does not exist or is not accessible: ${privateKeyPath}`,
+    );
   });
 
   it('should validate path must be a zip file', async () => {
@@ -354,7 +356,7 @@ describe('apps-liveupdates-register', () => {
       rolloutPercentage: 1,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
 
     // Mock zip utility to return false
     const mockZip = await import('@/utils/zip.js');

--- a/src/commands/apps/liveupdates/register.ts
+++ b/src/commands/apps/liveupdates/register.ts
@@ -5,7 +5,7 @@ import { withAuth } from '@/utils/auth.js';
 import { parseCustomProperties } from '@/utils/custom-properties.js';
 import { createBufferFromPath, createBufferFromString, isPrivateKeyContent } from '@/utils/buffer.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath } from '@/utils/file.js';
+import { isReadable } from '@/utils/file.js';
 import { createHash } from '@/utils/hash.js';
 import { formatPrivateKey } from '@/utils/private-key.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
@@ -192,9 +192,9 @@ export default defineCommand({
       }
 
       // Check if the path exists
-      const pathExists = await fileExistsAtPath(path);
-      if (!pathExists) {
-        consola.error(`The path does not exist.`);
+      const pathReadable = await isReadable(path);
+      if (!pathReadable) {
+        consola.error(`The path does not exist or is not accessible: ${path}`);
         process.exit(1);
       }
 
@@ -213,14 +213,14 @@ export default defineCommand({
           privateKeyBuffer = createBufferFromString(formattedPrivateKey);
         } else if (privateKey.endsWith('.pem')) {
           // Handle file path
-          const fileExists = await fileExistsAtPath(privateKey);
-          if (fileExists) {
+          const privateKeyReadable = await isReadable(privateKey);
+          if (privateKeyReadable) {
             const keyBuffer = await createBufferFromPath(privateKey);
             const keyContent = keyBuffer.toString('utf8');
             const formattedPrivateKey = formatPrivateKey(keyContent);
             privateKeyBuffer = createBufferFromString(formattedPrivateKey);
           } else {
-            consola.error('Private key file not found.');
+            consola.error(`The private key file does not exist or is not accessible: ${privateKey}`);
             process.exit(1);
           }
         } else {

--- a/src/commands/apps/liveupdates/upload.test.ts
+++ b/src/commands/apps/liveupdates/upload.test.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
 import authorizationService from '@/services/authorization-service.js';
 import { isInteractive } from '@/utils/environment.js';
-import { fileExistsAtPath, getFilesInDirectoryAndSubdirectories, isDirectory } from '@/utils/file.js';
+import { isReadable, getFilesInDirectoryAndSubdirectories, isDirectory } from '@/utils/file.js';
 import userConfig from '@/utils/user-config.js';
 import consola from 'consola';
 import nock from 'nock';
@@ -25,7 +25,7 @@ vi.mock('consola');
 describe('apps-liveupdates-upload', () => {
   const mockUserConfig = vi.mocked(userConfig);
   const mockAuthorizationService = vi.mocked(authorizationService);
-  const mockFileExistsAtPath = vi.mocked(fileExistsAtPath);
+  const mockIsReadable = vi.mocked(isReadable);
   const mockGetFilesInDirectoryAndSubdirectories = vi.mocked(getFilesInDirectoryAndSubdirectories);
   const mockIsDirectory = vi.mocked(isDirectory);
   const mockIsInteractive = vi.mocked(isInteractive);
@@ -68,11 +68,11 @@ describe('apps-liveupdates-upload', () => {
 
     const options = { appId, path: nonexistentPath, artifactType: 'zip' as const, rollout: 1 };
 
-    mockFileExistsAtPath.mockResolvedValue(false);
+    mockIsReadable.mockResolvedValue(false);
 
     await expect(uploadCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
 
-    expect(mockConsola.error).toHaveBeenCalledWith('The path does not exist.');
+    expect(mockConsola.error).toHaveBeenCalledWith(`The path does not exist or is not accessible: ${nonexistentPath}`);
   });
 
   it('should validate manifest artifact type requires directory', async () => {
@@ -86,7 +86,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(false);
 
     // Mock zip utility to return true so path validation passes
@@ -114,7 +114,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockGetFilesInDirectoryAndSubdirectories.mockResolvedValue([
       { href: 'index.html', mimeType: 'text/html', name: 'index.html', path: 'index.html' },
@@ -179,7 +179,7 @@ describe('apps-liveupdates-upload', () => {
       gitRef,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockGetFilesInDirectoryAndSubdirectories.mockResolvedValue([
       { href: 'index.html', mimeType: 'text/html', name: 'index.html', path: 'index.html' },
@@ -246,7 +246,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockImplementation((path: string) => {
+    mockIsReadable.mockImplementation((path: string) => {
       if (path === privateKeyPath) return Promise.resolve(true);
       if (path === bundlePath) return Promise.resolve(true);
       return Promise.resolve(false);
@@ -314,7 +314,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockImplementation((path: string) => {
+    mockIsReadable.mockImplementation((path: string) => {
       if (path === privateKeyPath) return Promise.resolve(false);
       return Promise.resolve(true);
     });
@@ -329,7 +329,9 @@ describe('apps-liveupdates-upload', () => {
 
     await expect(uploadCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
 
-    expect(mockConsola.error).toHaveBeenCalledWith('Private key file not found.');
+    expect(mockConsola.error).toHaveBeenCalledWith(
+      `The private key file does not exist or is not accessible: ${privateKeyPath}`,
+    );
   });
 
   it('should handle invalid private key format', async () => {
@@ -344,7 +346,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(false);
 
     // Mock zip utility to pass path validation
@@ -375,7 +377,7 @@ describe('apps-liveupdates-upload', () => {
       rollout: 1,
     };
 
-    mockFileExistsAtPath.mockResolvedValue(true);
+    mockIsReadable.mockResolvedValue(true);
     mockIsDirectory.mockResolvedValue(true);
     mockGetFilesInDirectoryAndSubdirectories.mockResolvedValue([
       { href: 'index.html', mimeType: 'text/html', name: 'index.html', path: 'index.html' },

--- a/src/commands/apps/liveupdates/upload.ts
+++ b/src/commands/apps/liveupdates/upload.ts
@@ -15,7 +15,7 @@ import { isInteractive } from '@/utils/environment.js';
 import {
   directoryContainsSourceMaps,
   directoryContainsSymlinks,
-  fileExistsAtPath,
+  isReadable,
   getFilesInDirectoryAndSubdirectories,
   isDirectory,
 } from '@/utils/file.js';
@@ -180,9 +180,9 @@ export default defineCommand({
     }
 
     // Validate the provided path
-    const pathExists = await fileExistsAtPath(path);
-    if (!pathExists) {
-      consola.error(`The path does not exist.`);
+    const pathReadable = await isReadable(path);
+    if (!pathReadable) {
+      consola.error(`The path does not exist or is not accessible: ${path}`);
       process.exit(1);
     }
 
@@ -267,14 +267,14 @@ export default defineCommand({
         privateKeyBuffer = createBufferFromString(formattedPrivateKey);
       } else if (privateKey.endsWith('.pem')) {
         // Handle file path
-        const fileExists = await fileExistsAtPath(privateKey);
-        if (fileExists) {
+        const privateKeyReadable = await isReadable(privateKey);
+        if (privateKeyReadable) {
           const keyBuffer = await createBufferFromPath(privateKey);
           const keyContent = keyBuffer.toString('utf8');
           const formattedPrivateKey = formatPrivateKey(keyContent);
           privateKeyBuffer = createBufferFromString(formattedPrivateKey);
         } else {
-          consola.error('Private key file not found.');
+          consola.error(`The private key file does not exist or is not accessible: ${privateKey}`);
           process.exit(1);
         }
       } else {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -50,9 +50,9 @@ export const directoryContainsSourceMaps = async (path: string): Promise<boolean
   return files.some((file) => file.name.endsWith('.js.map') || file.name.endsWith('.css.map'));
 };
 
-export const fileExistsAtPath = async (path: string): Promise<boolean> => {
+export const isReadable = async (path: string): Promise<boolean> => {
   return new Promise((resolve) => {
-    fs.access(path, fs.constants.F_OK, (err) => {
+    fs.access(path, fs.constants.R_OK, (err) => {
       resolve(!err);
     });
   });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -58,6 +58,14 @@ export const isReadable = async (path: string): Promise<boolean> => {
   });
 };
 
+export const pathExists = async (path: string): Promise<boolean> => {
+  return new Promise((resolve) => {
+    fs.access(path, fs.constants.F_OK, (err) => {
+      resolve(!err);
+    });
+  });
+};
+
 export const isDirectory = async (path: string): Promise<boolean> => {
   return new Promise((resolve) => {
     fs.lstat(path, (err, stats) => {


### PR DESCRIPTION
## Summary

- Renamed `fileExistsAtPath` to `isReadable` in `src/utils/file.ts` and switched from `F_OK` to `R_OK` so permission-denied files (e.g. macOS TCC-protected folders like `~/Downloads`) are caught at the access check instead of throwing `EPERM` from `readFileSync`.
- Updated all 14 call sites: variable names follow the `<noun>Readable` pattern, and error messages now consistently read `The <thing> does not exist or is not accessible: <path>`.
- Updated affected test mocks and expectations.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run fmt` reports no changes
- [x] `npm test` — all 157 tests pass
- [ ] Manually trigger a denied-access case on macOS (e.g. file in `~/Downloads` without TCC permission) and confirm the CLI prints the friendly error instead of crashing