### PR TITLE
fix(apps:builds:create): exclude native build artifact directories when zipping source

### DIFF
--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -22,7 +22,16 @@ class ZipImpl implements Zip {
     const files = await globby(['**/*'], {
       cwd: sourceFolder,
       gitignore: true,
-      ignore: ['.git/**'],
+      ignore: [
+        '.git/**',
+        '**/node_modules/**',
+        '**/ios/DerivedData/**',
+        '**/ios/Pods/**',
+        '**/ios/build/**',
+        '**/android/build/**',
+        '**/android/.gradle/**',
+        '**/android/app/build/**',
+      ],
       dot: true,
     });
     if (files.length > MAX_ZIP_ENTRIES) {


### PR DESCRIPTION
## Summary

- Prune common native build artifact directories (`node_modules`, `ios/DerivedData`, `ios/Pods`, `ios/build`, `android/build`, `android/.gradle`, `android/app/build`) directly via globby's `ignore` option in `zipFolderWithGitignore`.
- Fixes `ENAMETOOLONG: scandir` crashes during `apps:builds:create --path` when the source directory contains an Xcode `DerivedData/` tree. The recursive `purchases-root` symlink inside `purchases-ios-spm`'s Carthage installation fixture would otherwise blow past macOS's 1024-byte `PATH_MAX` during traversal.

## Why `.gitignore` wasn't enough

Globby drops gitignore patterns from fast-glob's `ignore` option whenever a parent `.gitignore` is found at the git root (see `convertPatternsForFastGlob` in `globby/utilities.js`). In that case gitignore is applied only as a post-traversal predicate, so fast-glob still `scandir`s into ignored directories before they can be filtered out. Passing the patterns through the explicit `ignore` array re-enables directory-level pruning.

## Test plan

- [ ] Run `apps:builds:create --path <capacitor-app-with-ios-DerivedData>` and confirm the command no longer crashes with `ENAMETOOLONG`.
- [ ] Verify the produced zip does not contain `node_modules/`, `ios/DerivedData/`, `ios/Pods/`, or Android build output.