### PR TITLE
feat(liveupdates): add experimental fingerprint commands

### DIFF
--- a/src/commands/apps/liveupdates/compare-fingerprints.ts
+++ b/src/commands/apps/liveupdates/compare-fingerprints.ts
@@ -1,0 +1,78 @@
+import { UserError } from '@/utils/error.js';
+import { pathExists } from '@/utils/file.js';
+import { diffFingerprints, type Fingerprint } from '@/utils/fingerprint/index.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { promises as fs } from 'fs';
+import pathModule from 'path';
+import { z } from 'zod';
+
+const loadFingerprintFile = async (fingerprintPath: string): Promise<Fingerprint> => {
+  const absolutePath = pathModule.resolve(process.cwd(), fingerprintPath);
+  if (!(await pathExists(absolutePath))) {
+    throw new UserError(`The fingerprint file does not exist: ${absolutePath}`);
+  }
+  const content = await fs.readFile(absolutePath, 'utf8');
+  try {
+    return JSON.parse(content) as Fingerprint;
+  } catch {
+    throw new UserError(`The fingerprint file is not a valid JSON file: ${absolutePath}`);
+  }
+};
+
+const OPERATION_SYMBOLS = {
+  added: '+',
+  removed: '-',
+  changed: '~',
+} as const;
+
+export default defineCommand({
+  description: '[Experimental] Compare two previously generated fingerprints.',
+  options: defineOptions(
+    z.object({
+      fingerprintPath: z
+        .array(z.string())
+        .optional()
+        .describe('Path to a fingerprint JSON file. Must be specified exactly twice.'),
+      json: z.boolean().optional().default(false).describe('Output the diff as JSON.'),
+    }),
+  ),
+  action: async (options, _args) => {
+    const { fingerprintPath, json } = options;
+
+    consola.warn('This command is experimental and may change in the future.');
+
+    if (!fingerprintPath || fingerprintPath.length !== 2) {
+      consola.error('You must provide exactly two `--fingerprint-path` options.');
+      process.exit(1);
+    }
+
+    const [fromPath, toPath] = fingerprintPath as [string, string];
+    const from = await loadFingerprintFile(fromPath);
+    const to = await loadFingerprintFile(toPath);
+
+    const diff = diffFingerprints(from, to);
+
+    if (json) {
+      console.log(JSON.stringify(diff, null, 2));
+      return;
+    }
+
+    if (diff.length === 0) {
+      consola.success('Fingerprints match.');
+      return;
+    }
+
+    let added = 0;
+    let removed = 0;
+    let changed = 0;
+    for (const item of diff) {
+      console.log(`${OPERATION_SYMBOLS[item.op]} ${item.path}`);
+      if (item.op === 'added') added++;
+      else if (item.op === 'removed') removed++;
+      else changed++;
+    }
+    console.log('');
+    console.log(`${diff.length} changes (${added} added, ${removed} removed, ${changed} changed)`);
+  },
+});

--- a/src/commands/apps/liveupdates/generate-fingerprint.ts
+++ b/src/commands/apps/liveupdates/generate-fingerprint.ts
@@ -1,0 +1,34 @@
+import { createFingerprint } from '@/utils/fingerprint/index.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import pathModule from 'path';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: '[Experimental] Generate a fingerprint of the native runtime for an Android or iOS build.',
+  options: defineOptions(
+    z.object({
+      platform: z.enum(['android', 'ios']).describe('The native platform to generate the fingerprint for.'),
+      path: z.string().optional().default('.').describe('Path to the project root directory. Defaults to `.`.'),
+      json: z.boolean().optional().default(false).describe('Output the full fingerprint as JSON.'),
+    }),
+  ),
+  action: async (options, _args) => {
+    const { platform, path, json } = options;
+
+    consola.warn('This command is experimental and may change in the future.');
+
+    const projectRoot = pathModule.resolve(process.cwd(), path);
+    const fingerprint = await createFingerprint({ projectRoot, platform });
+
+    if (json) {
+      console.log(JSON.stringify(fingerprint, null, 2));
+    } else {
+      consola.log(`App Type: ${fingerprint.appType}`);
+      consola.log(`Platform: ${fingerprint.platform}`);
+      consola.log(`Sources:  ${fingerprint.sources.length}`);
+      consola.log(`Hash:     ${fingerprint.hash}`);
+      consola.success('Fingerprint generated successfully.');
+    }
+  },
+});

--- a/src/commands/apps/liveupdates/verify-fingerprint.ts
+++ b/src/commands/apps/liveupdates/verify-fingerprint.ts
@@ -38,9 +38,9 @@ export default defineCommand({
         consola.error(`The fingerprint file does not exist: ${absolutePath}`);
         process.exit(1);
       }
+      const content = await fs.readFile(absolutePath, 'utf8');
       let fingerprint: Fingerprint;
       try {
-        const content = await fs.readFile(absolutePath, 'utf8');
         fingerprint = JSON.parse(content) as Fingerprint;
       } catch {
         throw new UserError(`The fingerprint file is not a valid JSON file: ${absolutePath}`);

--- a/src/commands/apps/liveupdates/verify-fingerprint.ts
+++ b/src/commands/apps/liveupdates/verify-fingerprint.ts
@@ -1,0 +1,72 @@
+import { UserError } from '@/utils/error.js';
+import { pathExists } from '@/utils/file.js';
+import { createFingerprint, type Fingerprint } from '@/utils/fingerprint/index.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { promises as fs } from 'fs';
+import pathModule from 'path';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: '[Experimental] Verify that the current project state matches a previously generated fingerprint.',
+  options: defineOptions(
+    z.object({
+      platform: z.enum(['android', 'ios']).describe('The native platform of the fingerprint to verify against.'),
+      path: z.string().optional().default('.').describe('Path to the project root directory. Defaults to `.`.'),
+      fingerprintPath: z.string().optional().describe('Path to a fingerprint JSON file to verify against.'),
+      fingerprintHash: z.string().optional().describe('Hash string to verify against.'),
+    }),
+  ),
+  action: async (options, _args) => {
+    const { platform, path, fingerprintPath, fingerprintHash } = options;
+
+    consola.warn('This command is experimental and may change in the future.');
+
+    if (!fingerprintPath && !fingerprintHash) {
+      consola.error('You must provide either `--fingerprint-path` or `--fingerprint-hash`.');
+      process.exit(1);
+    }
+    if (fingerprintPath && fingerprintHash) {
+      consola.error('You can only provide one of `--fingerprint-path` or `--fingerprint-hash`.');
+      process.exit(1);
+    }
+
+    let expectedHash: string;
+    if (fingerprintPath) {
+      const absolutePath = pathModule.resolve(process.cwd(), fingerprintPath);
+      if (!(await pathExists(absolutePath))) {
+        consola.error(`The fingerprint file does not exist: ${absolutePath}`);
+        process.exit(1);
+      }
+      let fingerprint: Fingerprint;
+      try {
+        const content = await fs.readFile(absolutePath, 'utf8');
+        fingerprint = JSON.parse(content) as Fingerprint;
+      } catch {
+        throw new UserError(`The fingerprint file is not a valid JSON file: ${absolutePath}`);
+      }
+      if (fingerprint.platform !== platform) {
+        consola.error(
+          `The fingerprint file is for platform "${fingerprint.platform}" but "${platform}" was requested.`,
+        );
+        process.exit(1);
+      }
+      expectedHash = fingerprint.hash;
+    } else {
+      expectedHash = fingerprintHash as string;
+    }
+
+    const projectRoot = pathModule.resolve(process.cwd(), path);
+    const current = await createFingerprint({ projectRoot, platform });
+
+    if (current.hash === expectedHash) {
+      consola.success('Fingerprint matches.');
+      process.exit(0);
+    } else {
+      consola.error(
+        'Fingerprint does not match. Run `apps:liveupdates:comparefingerprints` to get a list of changed files.',
+      );
+      process.exit(1);
+    }
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,15 @@ const config = defineConfig({
     'apps:liveupdates:generatemanifest': await import('@/commands/apps/liveupdates/generate-manifest.js').then(
       (mod) => mod.default,
     ),
+    'apps:liveupdates:generatefingerprint': await import('@/commands/apps/liveupdates/generate-fingerprint.js').then(
+      (mod) => mod.default,
+    ),
+    'apps:liveupdates:verifyfingerprint': await import('@/commands/apps/liveupdates/verify-fingerprint.js').then(
+      (mod) => mod.default,
+    ),
+    'apps:liveupdates:comparefingerprints': await import('@/commands/apps/liveupdates/compare-fingerprints.js').then(
+      (mod) => mod.default,
+    ),
     'manifests:generate': await import('@/commands/manifests/generate.js').then((mod) => mod.default),
     'organizations:create': await import('@/commands/organizations/create.js').then((mod) => mod.default),
     'organizations:get': await import('@/commands/organizations/get.js').then((mod) => mod.default),

--- a/src/utils/fingerprint/app-types.ts
+++ b/src/utils/fingerprint/app-types.ts
@@ -1,0 +1,18 @@
+import { UserError } from '@/utils/error.js';
+import capacitorAdapter from './app-types/capacitor.js';
+import type { AppTypeAdapter } from './types.js';
+
+const adapters: AppTypeAdapter[] = [capacitorAdapter];
+
+export const detectAppType = async (projectRoot: string): Promise<AppTypeAdapter> => {
+  for (const adapter of adapters) {
+    if (await adapter.detect(projectRoot)) {
+      return adapter;
+    }
+  }
+  throw new UserError(
+    `No supported app type was detected at the given path. Supported app types: ${adapters
+      .map((a) => a.name)
+      .join(', ')}.`,
+  );
+};

--- a/src/utils/fingerprint/app-types/capacitor.ts
+++ b/src/utils/fingerprint/app-types/capacitor.ts
@@ -1,0 +1,57 @@
+import { pathExists } from '@/utils/file.js';
+import { loadConfig } from 'c12';
+import pathModule from 'path';
+import type { AppTypeAdapter, FingerprintPlatform } from '../types.js';
+
+const CAPACITOR_CONFIG_FILES = ['capacitor.config.ts', 'capacitor.config.json', 'capacitor.config.js'];
+
+interface CapacitorConfig {
+  android?: { path?: string };
+  ios?: { path?: string };
+}
+
+const findConfigFile = async (projectRoot: string): Promise<string | undefined> => {
+  for (const fileName of CAPACITOR_CONFIG_FILES) {
+    const absolutePath = pathModule.join(projectRoot, fileName);
+    if (await pathExists(absolutePath)) {
+      return absolutePath;
+    }
+  }
+  return undefined;
+};
+
+const loadCapacitorConfig = async (projectRoot: string): Promise<CapacitorConfig> => {
+  const { config } = await loadConfig<CapacitorConfig>({
+    name: 'capacitor',
+    cwd: projectRoot,
+    rcFile: false,
+    globalRc: false,
+    dotenv: false,
+    packageJson: false,
+  });
+  return config ?? {};
+};
+
+const capacitorAdapter: AppTypeAdapter = {
+  name: 'capacitor',
+  async detect(projectRoot) {
+    const configFile = await findConfigFile(projectRoot);
+    return configFile !== undefined;
+  },
+  async resolvePlatformDir(projectRoot, platform: FingerprintPlatform) {
+    const config = await loadCapacitorConfig(projectRoot);
+    const customPath = platform === 'android' ? config.android?.path : config.ios?.path;
+    const relativePath = customPath ?? platform;
+    return pathModule.resolve(projectRoot, relativePath);
+  },
+  async getAdditionalSources(projectRoot) {
+    const sources: string[] = [];
+    const configFile = await findConfigFile(projectRoot);
+    if (configFile) {
+      sources.push(configFile);
+    }
+    return sources;
+  },
+};
+
+export default capacitorAdapter;

--- a/src/utils/fingerprint/index.ts
+++ b/src/utils/fingerprint/index.ts
@@ -1,6 +1,6 @@
 import { createBufferFromPath } from '@/utils/buffer.js';
 import { UserError } from '@/utils/error.js';
-import { pathExists, isDirectory } from '@/utils/file.js';
+import { isDirectory, pathExists } from '@/utils/file.js';
 import { createHash } from '@/utils/hash.js';
 import pathModule from 'path';
 import { detectAppType } from './app-types.js';

--- a/src/utils/fingerprint/index.ts
+++ b/src/utils/fingerprint/index.ts
@@ -1,0 +1,136 @@
+import { createBufferFromPath } from '@/utils/buffer.js';
+import { UserError } from '@/utils/error.js';
+import { pathExists, isDirectory } from '@/utils/file.js';
+import { createHash } from '@/utils/hash.js';
+import pathModule from 'path';
+import { detectAppType } from './app-types.js';
+import {
+  FINGERPRINT_HASH_ALGORITHM,
+  FINGERPRINT_VERSION,
+  type Fingerprint,
+  type FingerprintDiffItem,
+  type FingerprintPlatform,
+  type FingerprintSource,
+} from './types.js';
+import { walkDirectory } from './walker.js';
+
+const LOCK_FILES = ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb'];
+
+const findLockFile = async (projectRoot: string): Promise<string | undefined> => {
+  for (const fileName of LOCK_FILES) {
+    const absolutePath = pathModule.join(projectRoot, fileName);
+    if (await pathExists(absolutePath)) {
+      return absolutePath;
+    }
+  }
+  return undefined;
+};
+
+const toRelativePath = (projectRoot: string, absolutePath: string): string => {
+  const relative = pathModule.relative(projectRoot, absolutePath);
+  return relative.split(pathModule.sep).join('/');
+};
+
+export const createFingerprint = async (options: {
+  projectRoot: string;
+  platform: FingerprintPlatform;
+}): Promise<Fingerprint> => {
+  const { projectRoot, platform } = options;
+
+  const projectRootExists = await pathExists(projectRoot);
+  if (!projectRootExists) {
+    throw new UserError(`The given path does not exist: ${projectRoot}`);
+  }
+  const projectRootIsDirectory = await isDirectory(projectRoot);
+  if (!projectRootIsDirectory) {
+    throw new UserError(`The given path is not a directory: ${projectRoot}`);
+  }
+
+  const appType = await detectAppType(projectRoot);
+
+  const platformDir = await appType.resolvePlatformDir(projectRoot, platform);
+  const platformDirExists = await pathExists(platformDir);
+  if (!platformDirExists) {
+    throw new UserError(`The ${platform} project directory was not found at: ${platformDir}`);
+  }
+  const platformDirIsDirectory = await isDirectory(platformDir);
+  if (!platformDirIsDirectory) {
+    throw new UserError(`The ${platform} project path is not a directory: ${platformDir}`);
+  }
+
+  const absolutePaths = new Set<string>();
+  for (const file of await walkDirectory(platformDir)) {
+    absolutePaths.add(file);
+  }
+
+  const additionalSources = await appType.getAdditionalSources(projectRoot);
+  for (const source of additionalSources) {
+    if (await pathExists(source)) {
+      absolutePaths.add(source);
+    }
+  }
+
+  const packageJsonPath = pathModule.join(projectRoot, 'package.json');
+  if (await pathExists(packageJsonPath)) {
+    absolutePaths.add(packageJsonPath);
+  }
+  const lockFilePath = await findLockFile(projectRoot);
+  if (lockFilePath) {
+    absolutePaths.add(lockFilePath);
+  }
+
+  const sources: FingerprintSource[] = [];
+  for (const absolutePath of absolutePaths) {
+    const buffer = await createBufferFromPath(absolutePath);
+    const hash = await createHash(buffer);
+    sources.push({
+      path: toRelativePath(projectRoot, absolutePath),
+      hash,
+    });
+  }
+  sources.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const finalHash = await createHash(Buffer.from(JSON.stringify(sources)));
+
+  return {
+    version: FINGERPRINT_VERSION,
+    appType: appType.name,
+    platform,
+    hash: finalHash,
+    hashAlgorithm: FINGERPRINT_HASH_ALGORITHM,
+    createdAt: new Date().toISOString(),
+    sources,
+  };
+};
+
+export const diffFingerprints = (from: Fingerprint, to: Fingerprint): FingerprintDiffItem[] => {
+  if (from.appType !== to.appType) {
+    throw new UserError(`Cannot compare fingerprints with different app types: "${from.appType}" and "${to.appType}".`);
+  }
+  if (from.platform !== to.platform) {
+    throw new UserError(
+      `Cannot compare fingerprints with different platforms: "${from.platform}" and "${to.platform}".`,
+    );
+  }
+
+  const fromByPath = new Map(from.sources.map((source) => [source.path, source.hash]));
+  const toByPath = new Map(to.sources.map((source) => [source.path, source.hash]));
+  const allPaths = new Set<string>([...fromByPath.keys(), ...toByPath.keys()]);
+
+  const items: FingerprintDiffItem[] = [];
+  for (const path of allPaths) {
+    const fromHash = fromByPath.get(path);
+    const toHash = toByPath.get(path);
+    if (fromHash === undefined && toHash !== undefined) {
+      items.push({ op: 'added', path });
+    } else if (fromHash !== undefined && toHash === undefined) {
+      items.push({ op: 'removed', path });
+    } else if (fromHash !== toHash) {
+      items.push({ op: 'changed', path });
+    }
+  }
+  items.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return items;
+};
+
+export * from './types.js';

--- a/src/utils/fingerprint/types.ts
+++ b/src/utils/fingerprint/types.ts
@@ -1,0 +1,54 @@
+export type FingerprintPlatform = 'android' | 'ios';
+
+export type FingerprintAppType = 'capacitor';
+
+export const FINGERPRINT_VERSION = 1;
+
+export const FINGERPRINT_HASH_ALGORITHM = 'sha256';
+
+export interface FingerprintSource {
+  /**
+   * The file path relative to the project root.
+   *
+   * @example 'android/app/build.gradle'
+   */
+  path: string;
+  /**
+   * The SHA-256 hash of the file contents.
+   */
+  hash: string;
+}
+
+export interface Fingerprint {
+  version: typeof FINGERPRINT_VERSION;
+  appType: FingerprintAppType;
+  platform: FingerprintPlatform;
+  hash: string;
+  hashAlgorithm: typeof FINGERPRINT_HASH_ALGORITHM;
+  createdAt: string;
+  sources: FingerprintSource[];
+}
+
+export type FingerprintDiffOperation = 'added' | 'removed' | 'changed';
+
+export interface FingerprintDiffItem {
+  op: FingerprintDiffOperation;
+  path: string;
+}
+
+export interface AppTypeAdapter {
+  readonly name: FingerprintAppType;
+  /**
+   * Returns `true` if this app type is present at the given project root.
+   */
+  detect(projectRoot: string): Promise<boolean>;
+  /**
+   * Resolves the absolute path to the native platform directory.
+   */
+  resolvePlatformDir(projectRoot: string, platform: FingerprintPlatform): Promise<string>;
+  /**
+   * Returns absolute paths to additional files that should be included in the fingerprint
+   * beyond the platform directory and the standard package.json/lockfile.
+   */
+  getAdditionalSources(projectRoot: string): Promise<string[]>;
+}

--- a/src/utils/fingerprint/walker.ts
+++ b/src/utils/fingerprint/walker.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import { globby } from 'globby';
+import pathModule from 'path';
+
+/**
+ * Walks the given directory and returns absolute paths of all files,
+ * respecting `.gitignore` rules. Symbolic links and `.gitignore` files are skipped.
+ */
+export const walkDirectory = async (directory: string): Promise<string[]> => {
+  const entries = await globby('**/*', {
+    cwd: directory,
+    absolute: true,
+    dot: true,
+    gitignore: true,
+    onlyFiles: true,
+    followSymbolicLinks: false,
+    suppressErrors: true,
+  });
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const baseName = pathModule.basename(entry);
+    if (baseName === '.gitignore') {
+      continue;
+    }
+    try {
+      const stats = await fs.promises.lstat(entry);
+      if (stats.isSymbolicLink()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    files.push(entry);
+  }
+  return files;
+};


### PR DESCRIPTION
## Summary

Add three new experimental commands under `apps:liveupdates:*` for fingerprinting the native runtime of Capacitor apps. Fingerprints help ensure compatibility between the native code and the JS bundle, which is critical for live updates.

- `apps:liveupdates:generatefingerprint` — generate a SHA-256 fingerprint of the native runtime for a given platform (Android or iOS). Prints the hash by default; `--json` emits the full fingerprint document.
- `apps:liveupdates:verifyfingerprint` — verify the current project state against a previously generated fingerprint (either a `--fingerprint-path` file or a raw `--fingerprint-hash`). Exits `0` on match, `1` on mismatch.
- `apps:liveupdates:comparefingerprints` — compare two fingerprint JSON files and print a diff (`added`/`removed`/`changed`). `--json` emits the diff as JSON.

All three commands print an experimental warning at runtime and are labeled `[Experimental]` in their descriptions.

## What gets hashed

- The resolved native platform directory (`android/` or `ios/`, honoring `android.path` / `ios.path` from `capacitor.config.{ts,json,js}`).
- The Capacitor configuration file.
- `package.json` and the first-detected lockfile (`package-lock.json` → `yarn.lock` → `pnpm-lock.yaml` → `bun.lockb`).

Files ignored via project `.gitignore` rules are skipped automatically. `.gitignore` files themselves and symbolic links are also skipped.

## Architecture

Built around an `AppTypeAdapter` interface so additional app types (e.g. Cordova) can be added later without changes to the command layer. Capacitor is the only adapter for now.

## Test plan

- [ ] `apps:liveupdates:generatefingerprint --platform android --path <capacitor-project>` prints a stable hash on repeated runs.
- [ ] `--json` emits a valid fingerprint document with `appType`, `platform`, `hash`, `sources`.
- [ ] `apps:liveupdates:verifyfingerprint --fingerprint-hash <hash>` exits `0` on match and `1` on mismatch.
- [ ] `apps:liveupdates:verifyfingerprint --fingerprint-path <file>` errors on platform mismatch.
- [ ] `apps:liveupdates:comparefingerprints` prints the expected `+`/`-`/`~` diff and errors on platform mismatch.
- [ ] Custom `android.path` / `ios.path` in `capacitor.config.ts` is honored.
- [ ] Project without `capacitor.config.*` produces a clear "no supported app type" error.