### PR TITLE
fix(apps:liveupdates): omit directory entries from bundle zip

### DIFF
--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -13,8 +13,16 @@ interface Zip {
 
 class ZipImpl implements Zip {
   async zipFolder(sourceFolder: string): Promise<Buffer> {
+    const files = await globby(['**/*'], {
+      cwd: sourceFolder,
+      dot: true,
+    });
     const zip = new AdmZip();
-    zip.addLocalFolder(sourceFolder);
+    for (const file of files) {
+      const filePath = path.join(sourceFolder, file);
+      const dirName = path.dirname(file);
+      zip.addLocalFile(filePath, dirName === '.' ? '' : dirName);
+    }
     return zip.toBuffer();
   }
 


### PR DESCRIPTION
## Summary
- `zipFolder` (used by `apps:liveupdates:upload` and `apps:liveupdates:bundle`) now writes only file entries, matching `zipFolderWithGitignore`. Empty directories and explicit directory headers are no longer included.
- Root cause: since v4.5.0 (`15a4179`, archiver → adm-zip), `addLocalFolder` walked the source via `findFiles` and wrote each directory entry with the on-disk Unix mode bits from `fs.statSync`. If a source directory had restrictive perms (e.g. `0500` on a CI checkout), those bits were baked into the bundle.
- On Android, `net.lingala.zip4j.ZipFile.extractAll` processes entries in order. It would create the parent (e.g. `assets/`) with no write bit, then fail with `Could not create directory: …/<subdir>` when trying to create children inside. Customers on plugin versions older than `@capawesome/capacitor-live-update@8.2.1` (which clears `setExternalFileAttributes` defensively) couldn't update their bundles at all.

## Test plan
- [x] Manual repro on macOS: source tree with `chmod 0500 assets/` + nested subdir + dotfile.
  - Before: zip contained `assets/` entry with mode `40500` and `assets/additional-locale/` entry with mode `40755`.
  - After: only file entries (`.hidden`, `assets/additional-locale/en.json`, `index.json`), no directory headers.
- [x] Dotfiles still included (parity with `addLocalFolder`'s default).
- [ ] Smoke test `apps:liveupdates:upload` end-to-end against a real Android device on a plugin version <8.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)