### PR TITLE
fix(apps:liveupdates): clear zip entry attrs to prevent Android extraction errors

### DIFF
--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -15,10 +15,24 @@ class ZipImpl implements Zip {
   async zipFolder(sourceFolder: string): Promise<Buffer> {
     const zip = new AdmZip();
     zip.addLocalFolder(sourceFolder);
+    // Strip external file attributes from every entry. `addLocalFolder` copies
+    // the source's Unix mode bits onto each entry, so a directory with e.g.
+    // `0500` on a CI checkout ends up in the bundle and makes `zip4j` on
+    // Android fail with "Could not create directory" when extracting children
+    // into that read-only parent. Clearing attrs lets the extractor fall back
+    // to its OS defaults. Mirrors the plugin-side workaround in live-update
+    // 8.2.1+ (`FileHeader.setExternalFileAttributes(null)`).
+    for (const entry of zip.getEntries()) {
+      entry.attr = 0;
+    }
     return zip.toBuffer();
   }
 
   async zipFolderWithGitignore(sourceFolder: string): Promise<Buffer> {
+    // Do NOT apply the `entry.attr = 0` workaround from `zipFolder` here.
+    // This method zips full project sources for `apps:builds:create`, which
+    // include executables like `gradlew` whose `0755` mode must survive the
+    // round-trip so the server-side build can run them.
     const files = await globby(['**/*'], {
       cwd: sourceFolder,
       gitignore: true,

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -30,9 +30,10 @@ class ZipImpl implements Zip {
 
   async zipFolderWithGitignore(sourceFolder: string): Promise<Buffer> {
     // Do NOT apply the `entry.attr = 0` workaround from `zipFolder` here.
-    // This method zips full project sources for `apps:builds:create`, which
-    // include executables like `gradlew` whose `0755` mode must survive the
-    // round-trip so the server-side build can run them.
+    // This method zips full project sources for server-side builds (callers:
+    // `apps:builds:create`, `apps:liveupdates:create`), which include
+    // executables like `gradlew` whose `0755` mode must survive the round-trip
+    // so the build runner can execute them.
     const files = await globby(['**/*'], {
       cwd: sourceFolder,
       gitignore: true,


### PR DESCRIPTION
## Summary

`zipFolder` (used by `apps:liveupdates:upload` and `apps:liveupdates:bundle`) now zeroes the external file attributes on every zip entry after `addLocalFolder`. This mirrors the plugin-side workaround shipped in `@capawesome/capacitor-live-update@8.2.1` (`FileHeader.setExternalFileAttributes(null)`), but applies it at bundle-creation time so users on older plugin versions also get the fix.

### Root cause

In v4.5.0 the bundle zipper switched from `archiver` to `adm-zip`. Internally `addLocalFolder` walks the source via `findFiles` and copies the source filesystem's Unix mode bits onto every zip entry. If a source directory carries restrictive perms (e.g. `0500`, common on CI checkouts and hardened Docker images), those bits get baked into the bundle.

On Android, `net.lingala.zip4j.ZipFile.extractAll` processes entries in order:

1. Creates `assets/` with the stored mode `0500` (no write bit).
2. Tries to create `assets/<subdir>/` inside it — `File.mkdirs()` returns `false` because the parent isn't writable.
3. Throws `Could not create directory: …/<subdir>`.

Customers on plugin versions older than 8.2.1 couldn't update their bundles at all.

### Fix

Clear `entry.attr` on every entry after `addLocalFolder`. With no Unix mode bits, the extractor falls back to its OS defaults (`0755` dirs / `0644` files on Android), and `mkdirs()` succeeds.

A comment on `zipFolderWithGitignore` documents why the same workaround must **not** be applied there — that method zips full project sources for `apps:builds:create`, where executable bits on `gradlew` etc. must survive.

## Test plan

- [x] Manual repro on macOS with `chmod 0500 assets/` + nested subdir + dotfile.
  - Before: `assets/` entry stored with mode `40500`, files with `100644`.
  - After: every entry stored with mode `0`. Directory entries and dotfiles still present.
- [ ] Smoke test `apps:liveupdates:upload` end-to-end against a real Android device on a live-update plugin version `<8.2.1`.