### PR TITLE
fix: hash and sign buffers in chunks to avoid `RangeError: data is too long`

### DIFF
--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,4 +1,10 @@
+const CHUNK_SIZE = 64 * 1024 * 1024;
+
 export const createHash = async (data: Buffer): Promise<string> => {
   const crypto = await import('crypto');
-  return crypto.createHash('sha256').update(data).digest('hex');
+  const hash = crypto.createHash('sha256');
+  for (let offset = 0; offset < data.length; offset += CHUNK_SIZE) {
+    hash.update(data.subarray(offset, offset + CHUNK_SIZE));
+  }
+  return hash.digest('hex');
 };

--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -1,8 +1,12 @@
+const CHUNK_SIZE = 64 * 1024 * 1024;
+
 export const createSignature = async (privateKey: Buffer, data: Buffer): Promise<string> => {
   const crypto = await import('crypto');
   const privateKeyObject = crypto.createPrivateKey(privateKey);
   const sign = crypto.createSign('sha256');
-  sign.update(data);
+  for (let offset = 0; offset < data.length; offset += CHUNK_SIZE) {
+    sign.update(data.subarray(offset, offset + CHUNK_SIZE));
+  }
   sign.end();
   return sign.sign(privateKeyObject).toString('base64');
 };


### PR DESCRIPTION
## Summary
- Iterate `.update()` over 64 MB chunks in `createHash` and `createSignature` to avoid Node's per-call `INT_MAX` size limit on `crypto.Hash#update` / `crypto.Sign#update`
- Fixes `RangeError: data is too long` thrown from `apps:liveupdates:upload` (and similar commands) when the zipped bundle exceeds ~2 GB

## Test plan
- [x] Verified chunked and single-shot implementations produce identical hashes and signatures across buffer sizes spanning the chunk boundary (0, 1 B, 1 KB, 1 MB, `CHUNK_SIZE - 1`, `CHUNK_SIZE`, `CHUNK_SIZE + 1`, `2 * CHUNK_SIZE`, `2 * CHUNK_SIZE + 12345`, `3.5 * CHUNK_SIZE`)
- [x] `npm run build`