### PR TITLE
feat(apps): derive platform from app type for single-platform apps

### DIFF
--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -3,6 +3,7 @@ import appBuildSourcesService from '@/services/app-build-sources.js';
 import appBuildsService from '@/services/app-builds.js';
 import appCertificatesService from '@/services/app-certificates.js';
 import appEnvironmentsService from '@/services/app-environments.js';
+import appsService from '@/services/apps.js';
 import { AppBuildArtifactDto } from '@/types/app-build.js';
 import { parseKeyValuePairs } from '@/utils/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
@@ -160,6 +161,14 @@ export default defineCommand({
       }
       const organizationId = await promptOrganizationSelection({ allowCreate: true });
       appId = await promptAppSelection(organizationId, { allowCreate: true });
+    }
+
+    // Derive platform from app type for single-platform apps
+    if (!platform) {
+      const app = await appsService.findOne({ appId });
+      if (app.type === 'android' || app.type === 'ios') {
+        platform = app.type;
+      }
     }
 
     // Prompt for platform if not provided

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -61,14 +61,14 @@ export default defineCommand({
         process.exit(1);
       }
     }
-    // 3. Derive platform from app type for single-platform apps
+    // Derive platform from app type for single-platform apps
     if (!platform) {
       const app = await appsService.findOne({ appId });
       if (app.type === 'android' || app.type === 'ios') {
         platform = app.type;
       }
     }
-    // 4. Select platform
+    // 3. Select platform
     if (!platform) {
       if (!isInteractive()) {
         consola.error('You must provide the platform when running in non-interactive environment.');

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -1,5 +1,6 @@
 import appCertificatesService from '@/services/app-certificates.js';
 import appProvisioningProfilesService from '@/services/app-provisioning-profiles.js';
+import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { isReadable } from '@/utils/file.js';
@@ -60,7 +61,14 @@ export default defineCommand({
         process.exit(1);
       }
     }
-    // 3. Select platform
+    // 3. Derive platform from app type for single-platform apps
+    if (!platform) {
+      const app = await appsService.findOne({ appId });
+      if (app.type === 'android' || app.type === 'ios') {
+        platform = app.type;
+      }
+    }
+    // 4. Select platform
     if (!platform) {
       if (!isInteractive()) {
         consola.error('You must provide the platform when running in non-interactive environment.');

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -77,14 +77,14 @@ export default defineCommand({
         process.exit(1);
       }
     }
-    // 3. Derive platform from app type for single-platform apps
+    // Derive platform from app type for single-platform apps
     if (!platform) {
       const app = await appsService.findOne({ appId });
       if (app.type === 'android' || app.type === 'ios') {
         platform = app.type;
       }
     }
-    // 4. Select platform
+    // 3. Select platform
     if (!platform) {
       if (!isInteractive()) {
         consola.error('You must provide the platform when running in non-interactive environment.');

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -1,6 +1,7 @@
 import appAppleApiKeysService from '@/services/app-apple-api-keys.js';
 import appDestinationsService from '@/services/app-destinations.js';
 import appGoogleServiceAccountKeysService from '@/services/app-google-service-account-keys.js';
+import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { isReadable } from '@/utils/file.js';
@@ -76,7 +77,14 @@ export default defineCommand({
         process.exit(1);
       }
     }
-    // 3. Select platform
+    // 3. Derive platform from app type for single-platform apps
+    if (!platform) {
+      const app = await appsService.findOne({ appId });
+      if (app.type === 'android' || app.type === 'ios') {
+        platform = app.type;
+      }
+    }
+    // 4. Select platform
     if (!platform) {
       if (!isInteractive()) {
         consola.error('You must provide the platform when running in non-interactive environment.');

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,6 +1,7 @@
 export interface AppDto {
   id: string;
   name: string;
+  type: AppType;
 }
 
 export type AppType = 'android' | 'capacitor' | 'cordova' | 'ios';


### PR DESCRIPTION
## Problem

Running `apps:builds:create` (and `apps:certificates:create`, `apps:destinations:create`) without `--platform` in a non-interactive environment fails with `You must provide a platform when running in non-interactive environment.` — even for apps that only support a single platform (`android` or `ios`).

## Changes

- Expose `type` on `AppDto` so the app's type is available after `findOne`.
- When `--platform` is omitted, derive the platform from the app type for single-platform apps (`android`/`ios`) before falling back to the prompt/error.

This applies to three commands whose flow branches on `platform`:

- `apps:builds:create`
- `apps:certificates:create`
- `apps:destinations:create`

Ambiguous app types (`capacitor`, `cordova`) keep the existing behavior: prompt in interactive mode, error in non-interactive mode.