### PR TITLE
feat(environments): add `get` command and `--name` option to `set`/`unset`

### DIFF
--- a/src/commands/apps/environments/get.ts
+++ b/src/commands/apps/environments/get.ts
@@ -1,0 +1,70 @@
+import appEnvironmentsService from '@/services/app-environments.js';
+import { AppEnvironmentDto } from '@/types/app-environment.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Get an existing environment.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      environmentId: z.string().optional().describe('ID of the environment. Either the ID or name must be provided.'),
+      name: z.string().optional().describe('Name of the environment. Either the ID or name must be provided.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
+    }),
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, environmentId, name, json } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    if (!environmentId && !name) {
+      if (!isInteractive()) {
+        consola.error(
+          'You must provide either the environment ID or name when running in non-interactive environment.',
+        );
+        process.exit(1);
+      }
+      const environments = await appEnvironmentsService.findAll({ appId });
+      if (!environments.length) {
+        consola.error('No environments found for this app. Create one first.');
+        process.exit(1);
+      }
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      environmentId = await prompt('Select the environment:', {
+        type: 'select',
+        options: environments.map((env) => ({ label: env.name, value: env.id })),
+      });
+    }
+
+    let environment: AppEnvironmentDto | undefined;
+    if (environmentId) {
+      environment = await appEnvironmentsService.findOneById({ appId, id: environmentId });
+    } else if (name) {
+      const environments = await appEnvironmentsService.findAll({ appId, name });
+      environment = environments[0];
+    }
+    if (!environment) {
+      consola.error('Environment not found.');
+      process.exit(1);
+    }
+
+    if (json) {
+      console.log(JSON.stringify(environment, null, 2));
+    } else {
+      console.table(environment);
+      consola.success('Environment retrieved successfully.');
+    }
+  }),
+});

--- a/src/commands/apps/environments/set.ts
+++ b/src/commands/apps/environments/set.ts
@@ -14,7 +14,8 @@ export default defineCommand({
   options: defineOptions(
     z.object({
       appId: z.string().optional().describe('ID of the app.'),
-      environmentId: z.string().optional().describe('ID of the environment.'),
+      environmentId: z.string().optional().describe('ID of the environment. Either the ID or name must be provided.'),
+      name: z.string().optional().describe('Name of the environment. Either the ID or name must be provided.'),
       variable: z
         .array(z.string())
         .optional()
@@ -28,7 +29,7 @@ export default defineCommand({
     }),
   ),
   action: withAuth(async (options, args) => {
-    let { appId, environmentId, variable, variableFile, secret, secretFile } = options;
+    let { appId, environmentId, name, variable, variableFile, secret, secretFile } = options;
 
     if (!appId) {
       if (!isInteractive()) {
@@ -40,20 +41,32 @@ export default defineCommand({
     }
 
     if (!environmentId) {
-      if (!isInteractive()) {
-        consola.error('You must provide an environment ID when running in non-interactive environment.');
-        process.exit(1);
+      if (name) {
+        const environments = await appEnvironmentsService.findAll({ appId, name });
+        const environment = environments[0];
+        if (!environment) {
+          consola.error('Environment not found.');
+          process.exit(1);
+        }
+        environmentId = environment.id;
+      } else {
+        if (!isInteractive()) {
+          consola.error(
+            'You must provide either the environment ID or name when running in non-interactive environment.',
+          );
+          process.exit(1);
+        }
+        const environments = await appEnvironmentsService.findAll({ appId });
+        if (!environments.length) {
+          consola.error('No environments found for this app. Create one first.');
+          process.exit(1);
+        }
+        // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+        environmentId = await prompt('Select the environment:', {
+          type: 'select',
+          options: environments.map((env) => ({ label: env.name, value: env.id })),
+        });
       }
-      const environments = await appEnvironmentsService.findAll({ appId });
-      if (!environments.length) {
-        consola.error('No environments found for this app. Create one first.');
-        process.exit(1);
-      }
-      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
-      environmentId = await prompt('Select the environment:', {
-        type: 'select',
-        options: environments.map((env) => ({ label: env.name, value: env.id })),
-      });
     }
 
     // Parse variables from inline and file

--- a/src/commands/apps/environments/unset.ts
+++ b/src/commands/apps/environments/unset.ts
@@ -64,16 +64,6 @@ export default defineCommand({
       }
     }
 
-    if (!environmentId && name) {
-      const environments = await appEnvironmentsService.findAll({ appId, name });
-      const environment = environments[0];
-      if (!environment) {
-        consola.error('Environment not found.');
-        process.exit(1);
-      }
-      environmentId = environment.id;
-    }
-
     if (!variableKeys?.length && !secretKeys?.length) {
       consola.error('You must provide at least one variable key or secret key to unset.');
       process.exit(1);

--- a/src/commands/apps/environments/unset.ts
+++ b/src/commands/apps/environments/unset.ts
@@ -11,7 +11,8 @@ export default defineCommand({
   options: defineOptions(
     z.object({
       appId: z.string().optional().describe('ID of the app.'),
-      environmentId: z.string().optional().describe('ID of the environment.'),
+      environmentId: z.string().optional().describe('ID of the environment. Either the ID or name must be provided.'),
+      name: z.string().optional().describe('Name of the environment. Either the ID or name must be provided.'),
       variable: z
         .array(z.string())
         .optional()
@@ -23,7 +24,7 @@ export default defineCommand({
     }),
   ),
   action: withAuth(async (options, args) => {
-    let { appId, environmentId, variable: variableKeys, secret: secretKeys } = options;
+    let { appId, environmentId, name, variable: variableKeys, secret: secretKeys } = options;
 
     if (!appId) {
       if (!isInteractive()) {
@@ -35,20 +36,42 @@ export default defineCommand({
     }
 
     if (!environmentId) {
-      if (!isInteractive()) {
-        consola.error('You must provide an environment ID when running in non-interactive environment.');
+      if (name) {
+        const environments = await appEnvironmentsService.findAll({ appId, name });
+        const environment = environments[0];
+        if (!environment) {
+          consola.error('Environment not found.');
+          process.exit(1);
+        }
+        environmentId = environment.id;
+      } else {
+        if (!isInteractive()) {
+          consola.error(
+            'You must provide either the environment ID or name when running in non-interactive environment.',
+          );
+          process.exit(1);
+        }
+        const environments = await appEnvironmentsService.findAll({ appId });
+        if (!environments.length) {
+          consola.error('No environments found for this app. Create one first.');
+          process.exit(1);
+        }
+        // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+        environmentId = await prompt('Select the environment:', {
+          type: 'select',
+          options: environments.map((env) => ({ label: env.name, value: env.id })),
+        });
+      }
+    }
+
+    if (!environmentId && name) {
+      const environments = await appEnvironmentsService.findAll({ appId, name });
+      const environment = environments[0];
+      if (!environment) {
+        consola.error('Environment not found.');
         process.exit(1);
       }
-      const environments = await appEnvironmentsService.findAll({ appId });
-      if (!environments.length) {
-        consola.error('No environments found for this app. Create one first.');
-        process.exit(1);
-      }
-      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
-      environmentId = await prompt('Select the environment:', {
-        type: 'select',
-        options: environments.map((env) => ({ label: env.name, value: env.id })),
-      });
+      environmentId = environment.id;
     }
 
     if (!variableKeys?.length && !secretKeys?.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ const config = defineConfig({
     'apps:devices:unforcechannel': await import('@/commands/apps/devices/unforcechannel.js').then((mod) => mod.default),
     'apps:environments:create': await import('@/commands/apps/environments/create.js').then((mod) => mod.default),
     'apps:environments:delete': await import('@/commands/apps/environments/delete.js').then((mod) => mod.default),
+    'apps:environments:get': await import('@/commands/apps/environments/get.js').then((mod) => mod.default),
     'apps:environments:list': await import('@/commands/apps/environments/list.js').then((mod) => mod.default),
     'apps:environments:set': await import('@/commands/apps/environments/set.js').then((mod) => mod.default),
     'apps:environments:unset': await import('@/commands/apps/environments/unset.js').then((mod) => mod.default),

--- a/src/services/app-environments.ts
+++ b/src/services/app-environments.ts
@@ -4,6 +4,7 @@ import {
   CreateAppEnvironmentDto,
   DeleteAppEnvironmentDto,
   FindAllAppEnvironmentsDto,
+  FindOneAppEnvironmentByIdDto,
   SetEnvironmentSecretsDto,
   SetEnvironmentVariablesDto,
   UnsetEnvironmentSecretsDto,
@@ -15,6 +16,7 @@ export interface AppEnvironmentsService {
   create(dto: CreateAppEnvironmentDto): Promise<AppEnvironmentDto>;
   delete(dto: DeleteAppEnvironmentDto): Promise<void>;
   findAll(dto: FindAllAppEnvironmentsDto): Promise<AppEnvironmentDto[]>;
+  findOneById(dto: FindOneAppEnvironmentByIdDto): Promise<AppEnvironmentDto>;
   setVariables(dto: SetEnvironmentVariablesDto): Promise<void>;
   setSecrets(dto: SetEnvironmentSecretsDto): Promise<void>;
   unsetVariables(dto: UnsetEnvironmentVariablesDto): Promise<void>;
@@ -58,6 +60,9 @@ class AppEnvironmentsServiceImpl implements AppEnvironmentsService {
 
   async findAll(dto: FindAllAppEnvironmentsDto): Promise<AppEnvironmentDto[]> {
     const queryParams = new URLSearchParams();
+    if (dto.name) {
+      queryParams.append('name', dto.name);
+    }
     if (dto.limit) {
       queryParams.append('limit', dto.limit.toString());
     }
@@ -69,6 +74,15 @@ class AppEnvironmentsServiceImpl implements AppEnvironmentsService {
       ? `/v1/apps/${dto.appId}/environments?${queryString}`
       : `/v1/apps/${dto.appId}/environments`;
     const response = await this.httpClient.get<AppEnvironmentDto[]>(url, {
+      headers: {
+        Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+      },
+    });
+    return response.data;
+  }
+
+  async findOneById(dto: FindOneAppEnvironmentByIdDto): Promise<AppEnvironmentDto> {
+    const response = await this.httpClient.get<AppEnvironmentDto>(`/v1/apps/${dto.appId}/environments/${dto.id}`, {
       headers: {
         Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
       },

--- a/src/types/app-environment.ts
+++ b/src/types/app-environment.ts
@@ -6,8 +6,14 @@ export interface AppEnvironmentDto {
 
 export interface FindAllAppEnvironmentsDto {
   appId: string;
+  name?: string;
   limit?: number;
   offset?: number;
+}
+
+export interface FindOneAppEnvironmentByIdDto {
+  appId: string;
+  id: string;
 }
 
 export interface CreateAppEnvironmentDto {


### PR DESCRIPTION
## Summary

Adds a new `apps:environments:get` command and a `--name` option to the `apps:environments:set` and `apps:environments:unset` commands, so users no longer need to know the environment ID. This mirrors the existing behavior of `apps:environments:delete`.

## Changes

- **New command `apps:environments:get`**: Retrieves a single environment by `--environment-id` or `--name`. Supports `--json` output and the same interactive app/environment selection as sibling commands.
- **`apps:environments:set` / `apps:environments:unset`**: Added a `--name` option. When provided, the name is resolved to an environment ID client-side via the environments list (the set/unset endpoints require the ID in the path).
- **Service**: `findAll` now supports a `name` query param and a new `findOneById` method was added.
- **Types**: Added `name` to `FindAllAppEnvironmentsDto` and a new `FindOneAppEnvironmentByIdDto`.

## Notes

- `get` by ID relies on `GET /v1/apps/{appId}/environments/{id}`, and name resolution relies on the `?name=` filter on the environments list endpoint. The `DELETE` endpoint already supports `?name=`, so this is consistent, but should be confirmed against the API.