### PR TITLE
feat(liveupdates): add `--json` output to `upload` and align JSON keys in `create`

### DIFF
--- a/src/commands/apps/liveupdates/create.test.ts
+++ b/src/commands/apps/liveupdates/create.test.ts
@@ -299,6 +299,9 @@ describe('apps-liveupdates-create', () => {
     expect(console.log).toHaveBeenCalledWith(
       JSON.stringify(
         {
+          appBuildId: buildId,
+          appBuildNumberAsString: '42',
+          appDeploymentIds: [deploymentId],
           buildId,
           buildNumberAsString: '42',
           deploymentIds: [deploymentId],

--- a/src/commands/apps/liveupdates/create.ts
+++ b/src/commands/apps/liveupdates/create.ts
@@ -296,7 +296,7 @@ export default defineCommand({
 
     // Deploy to channels
     const rolloutPercentage = (options.rolloutPercentage ?? 100) / 100;
-    const deploymentIds: string[] = [];
+    const appDeploymentIds: string[] = [];
     for (const channelName of channel) {
       consola.start(`Creating deployment for channel "${channelName}"...`);
       const deployment = await appDeploymentsService.create({
@@ -305,7 +305,7 @@ export default defineCommand({
         appChannelName: channelName,
         rolloutPercentage,
       });
-      deploymentIds.push(deployment.id);
+      appDeploymentIds.push(deployment.id);
       consola.info(`Deployment ID: ${deployment.id}`);
       consola.info(`Deployment URL: ${DEFAULT_CONSOLE_BASE_URL}/apps/${appId}/deployments/${deployment.id}`);
       consola.success('Deployment created successfully.');
@@ -316,9 +316,12 @@ export default defineCommand({
       console.log(
         JSON.stringify(
           {
-            buildId: response.id,
-            buildNumberAsString: response.numberAsString,
-            deploymentIds,
+            appBuildId: response.id,
+            appBuildNumberAsString: response.numberAsString,
+            appDeploymentIds,
+            buildId: response.id, // Deprecated, use appBuildId instead
+            buildNumberAsString: response.numberAsString, // Deprecated, use appBuildNumberAsString instead
+            deploymentIds: appDeploymentIds, // Deprecated, use appDeploymentIds instead
           },
           null,
           2,

--- a/src/commands/apps/liveupdates/upload.test.ts
+++ b/src/commands/apps/liveupdates/upload.test.ts
@@ -228,6 +228,71 @@ describe('apps-liveupdates-upload', () => {
     expect(mockConsola.success).toHaveBeenCalledWith('Live Update successfully uploaded.');
   });
 
+  it('should output JSON when json flag is set', async () => {
+    const appId = 'app-123';
+    const bundlePath = './dist';
+    const bundleId = 'bundle-456';
+    const appBuildId = 'build-789';
+    const testToken = 'test-token';
+    const testBuffer = Buffer.from('test');
+
+    const options = {
+      appId,
+      path: bundlePath,
+      artifactType: 'zip' as const,
+      rollout: 1,
+      json: true,
+    };
+
+    mockIsReadable.mockResolvedValue(true);
+    mockIsDirectory.mockResolvedValue(true);
+    mockGetFilesInDirectoryAndSubdirectories.mockResolvedValue([
+      { href: 'index.html', mimeType: 'text/html', name: 'index.html', path: 'index.html' },
+    ]);
+
+    const mockZip = await import('@/utils/zip.js');
+    const mockHash = await import('@/utils/hash.js');
+
+    vi.mocked(mockZip.default.isZipped).mockReturnValue(false);
+    vi.mocked(mockZip.default.zipFolder).mockResolvedValue(testBuffer);
+    vi.mocked(mockHash.createHash).mockResolvedValue('test-hash');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { id: appId, name: 'Test App' });
+
+    nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/bundles`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: bundleId, appBuildId });
+
+    nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/bundles/${bundleId}/files`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: 'file-123' });
+
+    nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/bundles/${bundleId}`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { id: bundleId });
+
+    await uploadCommand.action(options, undefined);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          appBuildId,
+          appBuildArtifactId: bundleId,
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
   it('should handle private key file path', async () => {
     const appId = 'app-123';
     const bundlePath = './dist';

--- a/src/commands/apps/liveupdates/upload.ts
+++ b/src/commands/apps/liveupdates/upload.ts
@@ -108,6 +108,7 @@ export default defineCommand({
         .string()
         .optional()
         .describe('The exact iOS bundle version (`CFBundleVersion`) that the bundle does not support.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       path: z
         .string()
         .optional()
@@ -152,6 +153,7 @@ export default defineCommand({
       iosEq,
       iosMax,
       iosMin,
+      json,
       path,
       privateKey,
       rolloutPercentage,
@@ -348,6 +350,19 @@ export default defineCommand({
       );
     }
     consola.success('Live Update successfully uploaded.');
+
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            appBuildId: createBundleResponse.appBuildId,
+            appBuildArtifactId: createBundleResponse.id,
+          },
+          null,
+          2,
+        ),
+      );
+    }
   }),
 });
 

--- a/src/types/app-bundle.ts
+++ b/src/types/app-bundle.ts
@@ -1,5 +1,6 @@
 export interface AppBundleDto {
   id: string;
+  appBuildId?: string;
   appDeploymentId?: string | null;
 }
 


### PR DESCRIPTION
## Summary

Adds machine-readable JSON output to the `apps:liveupdates:upload` command and aligns the JSON output keys of the `apps:liveupdates:create` command for consistency.

### `upload`

- Adds a `--json` option that prints the `appBuildId` and `appBuildArtifactId` of the uploaded bundle.
- Adds `appBuildId` to the `AppBundleDto` type (already returned by the create-bundle API but previously not declared).

### `create`

- Renames the JSON output keys to `appBuildId`, `appBuildNumberAsString`, and `appDeploymentIds` for naming consistency.
- Keeps the previous `buildId`, `buildNumberAsString`, and `deploymentIds` keys as deprecated aliases for backwards compatibility.

## Test plan

- Added a test asserting the JSON output of `upload` when `--json` is set.
- Updated the `create` JSON output test to reflect the new key shape.
- All tests pass.