### PR TITLE
feat(deployments): include app build data in `list` and `get` JSON output

### DIFF
--- a/src/commands/apps/deployments/get.ts
+++ b/src/commands/apps/deployments/get.ts
@@ -28,7 +28,7 @@ export default defineCommand({
     const deployment = await appDeploymentsService.findOne({
       appId,
       appDeploymentId: deploymentId,
-      relations: json ? 'job' : undefined,
+      relations: json ? 'appBuild,job' : undefined,
     });
     if (json) {
       console.log(JSON.stringify(deployment, null, 2));

--- a/src/commands/apps/deployments/list.ts
+++ b/src/commands/apps/deployments/list.ts
@@ -38,7 +38,7 @@ export default defineCommand({
       appDestinationId: destinationId,
       limit,
       offset,
-      relations: json ? 'job' : undefined,
+      relations: json ? 'appBuild,job' : undefined,
     });
     if (json) {
       console.log(JSON.stringify(foundDeployments, null, 2));

--- a/src/types/app-build.ts
+++ b/src/types/app-build.ts
@@ -11,6 +11,7 @@ export interface AppBuildArtifactDto {
 
 export interface AppBuildDto {
   id: string;
+  appBuildArtifactId: string | null;
   appBuildArtifacts?: AppBuildArtifactDto[];
   appCertificateId?: string;
   appEnvironmentId?: string;


### PR DESCRIPTION
## Summary

The `apps:deployments:list --json` and `apps:deployments:get --json` commands now include the nested `appBuild` object in their output, so consumers can access app build data such as `appBuild.appBuildArtifactId` directly from a deployment.

## Changes

- Request the `appBuild` relation (alongside `job`) for JSON output in `deployments:list` and `deployments:get`.
- Add `appBuildArtifactId` to `AppBuildDto`.

Non-JSON (table) output is unchanged.