### PR TITLE
feat: add `--json` output to create and register commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ This project is structured as follows:
 - **Simplicity**: Keep code simple and readable.
 - **Type Safety**: Never use non-null assertions (`!`). Always write type-safe code. Non-null assertions are only allowed in test files.
 - **Zod Coercion for CLI Options**: Always use `z.coerce.number()` (not `z.number()`) for numeric CLI options, since CLI arguments are parsed as strings.
+- **`--json` Output**: Commands that return data take a `json` option (`z.boolean().optional().describe('Output in JSON format.')`) and print `console.log(JSON.stringify(data, null, 2))` with the resource's own field names (`{ id }`). Commands with progress output (spinners, step logs) keep that output and just append the JSON, since progress is useful in CI/CD. Commands without progress output use `if (json) { ...JSON... } else { ...consola... }` so `--json` stays clean.
 
 ## Philosophy
 

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -17,6 +17,7 @@ export default defineCommand({
     z.object({
       appId: z.string().optional().describe('ID of the app.'),
       file: z.string().optional().describe('Path to the certificate file.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       keyAlias: z.string().optional().describe('Key alias for the certificate.'),
       keyPassword: z.string().optional().describe('Key password for the certificate.'),
       name: z.string().optional().describe('Name of the certificate.'),
@@ -38,7 +39,7 @@ export default defineCommand({
     { y: 'yes' },
   ),
   action: withAuth(async (options, args) => {
-    let { appId, file, keyAlias, keyPassword, name, password, platform, provisioningProfile, type } = options;
+    let { appId, file, json, keyAlias, keyPassword, name, password, platform, provisioningProfile, type } = options;
 
     // 1. Select organization and app
     if (!appId) {
@@ -195,7 +196,11 @@ export default defineCommand({
       });
     }
 
-    consola.info(`Certificate ID: ${certificate.id}`);
-    consola.success('Certificate created successfully.');
+    if (json) {
+      console.log(JSON.stringify({ id: certificate.id }, null, 2));
+    } else {
+      consola.info(`Certificate ID: ${certificate.id}`);
+      consola.success('Certificate created successfully.');
+    }
   }),
 });

--- a/src/commands/apps/channels/create.test.ts
+++ b/src/commands/apps/channels/create.test.ts
@@ -66,6 +66,32 @@ describe('apps-channels-create', () => {
     expect(mockConsola.info).toHaveBeenCalledWith(`Channel ID: ${channelId}`);
   });
 
+  it('should output JSON when json flag is set', async () => {
+    const appId = 'app-123';
+    const channelName = 'production';
+    const channelId = 'channel-456';
+    const testToken = 'test-token';
+
+    const options = { appId, json: true, name: channelName };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/channels`, {
+        appId,
+        name: channelName,
+        protected: undefined,
+      })
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: channelId, name: channelName });
+
+    await createChannelCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ id: channelId }, null, 2));
+    expect(mockConsola.info).not.toHaveBeenCalled();
+  });
+
   it('should prompt for app when not provided', async () => {
     const channelName = 'staging';
     const orgId = 'org-1';

--- a/src/commands/apps/channels/create.ts
+++ b/src/commands/apps/channels/create.ts
@@ -22,12 +22,13 @@ export default defineCommand({
         .optional()
         .describe('The number of days until the channel is automatically deleted.'),
       ignoreErrors: z.boolean().optional().describe('Whether to ignore errors or not.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       name: z.string().optional().describe('Name of the channel.'),
       protected: z.boolean().optional().describe('Whether to protect the channel or not. Default is `false`.'),
     }),
   ),
   action: withAuth(async (options, args) => {
-    let { appId, expiresInDays, ignoreErrors, name, protected: _protected } = options;
+    let { appId, expiresInDays, ignoreErrors, json, name, protected: _protected } = options;
 
     if (expiresInDays) {
       consola.warn(
@@ -57,8 +58,12 @@ export default defineCommand({
         protected: _protected,
         name,
       });
-      consola.info(`Channel ID: ${response.id}`);
-      consola.success('Channel created successfully.');
+      if (json) {
+        console.log(JSON.stringify({ id: response.id }, null, 2));
+      } else {
+        consola.info(`Channel ID: ${response.id}`);
+        consola.success('Channel created successfully.');
+      }
     } catch (error) {
       if (ignoreErrors) {
         const message = getMessageFromUnknownError(error);

--- a/src/commands/apps/deployments/create.ts
+++ b/src/commands/apps/deployments/create.ts
@@ -38,10 +38,11 @@ export default defineCommand({
         .boolean()
         .optional()
         .describe('Request an AI-powered failure summary (Capawesome Cloud Assist) if the deployment fails.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
     }),
   ),
   action: withAuth(async (options) => {
-    let { appId, buildId, buildNumber, channel, destination } = options;
+    let { appId, buildId, buildNumber, channel, destination, json } = options;
 
     // Prompt for app ID if not provided
     if (!appId) {
@@ -185,7 +186,10 @@ export default defineCommand({
           }),
       });
       consola.success('Deployment completed successfully.');
-      process.exit(0);
+    }
+
+    if (json) {
+      console.log(JSON.stringify({ id: response.id }, null, 2));
     }
   }),
 });

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -17,6 +17,7 @@ export default defineCommand({
   options: defineOptions(
     z.object({
       appId: z.string().optional().describe('ID of the app.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       name: z.string().optional().describe('Name of the destination.'),
       platform: z.enum(['android', 'ios']).optional().describe('Platform of the destination (android, ios).'),
       appleId: z.string().optional().describe('Apple ID for the destination.'),
@@ -38,6 +39,7 @@ export default defineCommand({
   action: withAuth(async (options, args) => {
     let {
       appId,
+      json,
       name,
       platform,
       appleId,
@@ -353,7 +355,11 @@ export default defineCommand({
       appGoogleServiceAccountKeyId,
       googlePlayTrack,
     });
-    consola.info(`Destination ID: ${response.id}`);
-    consola.success('Destination created successfully.');
+    if (json) {
+      console.log(JSON.stringify({ id: response.id }, null, 2));
+    } else {
+      consola.info(`Destination ID: ${response.id}`);
+      consola.success('Destination created successfully.');
+    }
   }),
 });

--- a/src/commands/apps/environments/create.ts
+++ b/src/commands/apps/environments/create.ts
@@ -11,11 +11,12 @@ export default defineCommand({
   options: defineOptions(
     z.object({
       appId: z.string().optional().describe('ID of the app.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       name: z.string().optional().describe('Name of the environment.'),
     }),
   ),
   action: withAuth(async (options, args) => {
-    let { appId, name } = options;
+    let { appId, json, name } = options;
 
     if (!appId) {
       if (!isInteractive()) {
@@ -38,7 +39,11 @@ export default defineCommand({
       appId,
       name,
     });
-    consola.info(`Environment ID: ${response.id}`);
-    consola.success('Environment created successfully.');
+    if (json) {
+      console.log(JSON.stringify({ id: response.id }, null, 2));
+    } else {
+      consola.info(`Environment ID: ${response.id}`);
+      consola.success('Environment created successfully.');
+    }
   }),
 });

--- a/src/commands/apps/liveupdates/register.test.ts
+++ b/src/commands/apps/liveupdates/register.test.ts
@@ -92,6 +92,47 @@ describe('apps-liveupdates-register', () => {
     expect(mockConsola.success).toHaveBeenCalledWith('Live Update successfully registered.');
   });
 
+  it('should output JSON when json flag is set', async () => {
+    const appId = 'app-123';
+    const bundleUrl = 'https://example.com/bundle.zip';
+    const bundleId = 'bundle-456';
+    const appBuildId = 'build-789';
+    const testToken = 'test-token';
+
+    const options = {
+      appId,
+      url: bundleUrl,
+      rolloutPercentage: 1,
+      json: true,
+      yes: true,
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { id: appId, name: 'Test App' });
+
+    nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/bundles`)
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: bundleId, appBuildId });
+
+    await registerCommand.action(options, undefined);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          appBuildId,
+          appBuildArtifactId: bundleId,
+        },
+        null,
+        2,
+      ),
+    );
+  });
+
   it('should pass gitRef to API when provided', async () => {
     const appId = 'app-123';
     const bundleUrl = 'https://example.com/bundle.zip';

--- a/src/commands/apps/liveupdates/register.ts
+++ b/src/commands/apps/liveupdates/register.ts
@@ -85,6 +85,7 @@ export default defineCommand({
         .string()
         .optional()
         .describe('The exact iOS bundle version (`CFBundleVersion`) that the bundle does not support.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
       path: z.string().optional().describe('Path to zip file for code signing only.'),
       privateKey: z
         .string()
@@ -126,6 +127,7 @@ export default defineCommand({
       iosEq,
       iosMax,
       iosMin,
+      json,
       path,
       privateKey,
       rolloutPercentage,
@@ -286,5 +288,18 @@ export default defineCommand({
       consola.info(`Deployment URL: ${DEFAULT_CONSOLE_BASE_URL}/apps/${appId}/deployments/${response.appDeploymentId}`);
     }
     consola.success('Live Update successfully registered.');
+
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            appBuildId: response.appBuildId,
+            appBuildArtifactId: response.id,
+          },
+          null,
+          2,
+        ),
+      );
+    }
   }),
 });

--- a/src/commands/organizations/create.test.ts
+++ b/src/commands/organizations/create.test.ts
@@ -58,6 +58,27 @@ describe('organizations-create', () => {
     expect(mockConsola.info).toHaveBeenCalledWith(`Organization ID: ${organizationId}`);
   });
 
+  it('should output JSON when json flag is set', async () => {
+    const organizationName = 'Test Organization';
+    const organizationId = 'org-456';
+    const testToken = 'test-token';
+
+    const options = { json: true, name: organizationName };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post('/v1/organizations', { name: organizationName })
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: organizationId, name: organizationName });
+
+    await createOrganizationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ id: organizationId }, null, 2));
+    expect(mockConsola.info).not.toHaveBeenCalled();
+  });
+
   it('should prompt for organization name when not provided', async () => {
     const promptedOrganizationName = 'Prompted Organization';
     const organizationId = 'org-456';

--- a/src/commands/organizations/create.ts
+++ b/src/commands/organizations/create.ts
@@ -10,11 +10,12 @@ export default defineCommand({
   description: 'Create a new organization.',
   options: defineOptions(
     z.object({
+      json: z.boolean().optional().describe('Output in JSON format.'),
       name: z.string().optional().describe('Name of the organization.'),
     }),
   ),
   action: withAuth(async (options, args) => {
-    let { name } = options;
+    let { json, name } = options;
 
     if (!name) {
       if (!isInteractive()) {
@@ -24,7 +25,11 @@ export default defineCommand({
       name = await prompt('Enter the name of the organization:', { type: 'text' });
     }
     const response = await organizationsService.create({ name });
-    consola.info(`Organization ID: ${response.id}`);
-    consola.success('Organization created successfully.');
+    if (json) {
+      console.log(JSON.stringify({ id: response.id }, null, 2));
+    } else {
+      consola.info(`Organization ID: ${response.id}`);
+      consola.success('Organization created successfully.');
+    }
   }),
 });


### PR DESCRIPTION
## Summary

Adds `--json` output to the remaining commands that return data, and documents the convention in `CLAUDE.md`.

New `--json` support:

- `organizations:create`
- `apps:certificates:create`
- `apps:channels:create`
- `apps:destinations:create`
- `apps:environments:create`
- `apps:deployments:create`
- `apps:liveupdates:register`

## Convention

- Commands with progress output (spinners, step logs) keep that output and just append the JSON, since progress is useful in CI/CD (`apps:deployments:create`, `apps:liveupdates:register`).
- Commands without progress output use `if (json) { ...JSON... } else { ...consola... }` so `--json` stays clean (the `create` commands).
- The JSON uses the resource's own field names (`{ id }`). `apps:liveupdates:register` mirrors the `apps:liveupdates:upload` shape (`appBuildId`, `appBuildArtifactId`).

## Notes

- Removed a redundant `process.exit(0)` in `apps:deployments:create` so the JSON is printed last regardless of whether the command waits for the deployment job.
- Added tests for the commands that already have test files (`organizations:create`, `apps:channels:create`, `apps:liveupdates:register`).

## Test plan

- `npm run fmt`, `tsc --noEmit`, and the full test suite (161 tests) pass.