### PR TITLE
feat(environments): include variable and secret keys in get and list output

### DIFF
--- a/src/commands/apps/environments/get.ts
+++ b/src/commands/apps/environments/get.ts
@@ -48,11 +48,12 @@ export default defineCommand({
       });
     }
 
+    const relations = 'appEnvironmentVariables,appEnvironmentSecrets';
     let environment: AppEnvironmentDto | undefined;
     if (environmentId) {
-      environment = await appEnvironmentsService.findOneById({ appId, id: environmentId });
+      environment = await appEnvironmentsService.findOneById({ appId, id: environmentId, relations });
     } else if (name) {
-      const environments = await appEnvironmentsService.findAll({ appId, name });
+      const environments = await appEnvironmentsService.findAll({ appId, name, relations });
       environment = environments[0];
     }
     if (!environment) {
@@ -63,7 +64,14 @@ export default defineCommand({
     if (json) {
       console.log(JSON.stringify(environment, null, 2));
     } else {
-      console.table(environment);
+      const { appEnvironmentVariables, appEnvironmentSecrets, ...rest } = environment;
+      console.table(rest);
+      if (appEnvironmentVariables?.length) {
+        console.table(appEnvironmentVariables.map(({ id, key, value }) => ({ id, key, value })));
+      }
+      if (appEnvironmentSecrets?.length) {
+        console.table(appEnvironmentSecrets.map(({ id, key }) => ({ id, key })));
+      }
       consola.success('Environment retrieved successfully.');
     }
   }),

--- a/src/commands/apps/environments/list.ts
+++ b/src/commands/apps/environments/list.ts
@@ -30,6 +30,7 @@ export default defineCommand({
 
     const environments = await appEnvironmentsService.findAll({
       appId,
+      relations: json ? 'appEnvironmentVariables,appEnvironmentSecrets' : undefined,
       limit,
       offset,
     });
@@ -38,6 +39,7 @@ export default defineCommand({
       console.log(JSON.stringify(environments, null, 2));
     } else {
       console.table(environments);
+      consola.info('Run with --json to include variable keys and values and secret keys.');
       consola.success('Environments retrieved successfully.');
     }
   }),

--- a/src/commands/apps/environments/list.ts
+++ b/src/commands/apps/environments/list.ts
@@ -39,7 +39,7 @@ export default defineCommand({
       console.log(JSON.stringify(environments, null, 2));
     } else {
       console.table(environments);
-      consola.info('Run with --json to include variable keys and values and secret keys.');
+      consola.info('Run with --json to include variable keys/values and secret keys.');
       consola.success('Environments retrieved successfully.');
     }
   }),

--- a/src/services/app-environments.ts
+++ b/src/services/app-environments.ts
@@ -63,6 +63,9 @@ class AppEnvironmentsServiceImpl implements AppEnvironmentsService {
     if (dto.name) {
       queryParams.append('name', dto.name);
     }
+    if (dto.relations) {
+      queryParams.append('relations', dto.relations);
+    }
     if (dto.limit) {
       queryParams.append('limit', dto.limit.toString());
     }
@@ -86,6 +89,7 @@ class AppEnvironmentsServiceImpl implements AppEnvironmentsService {
       headers: {
         Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
       },
+      params: dto.relations ? { relations: dto.relations } : undefined,
     });
     return response.data;
   }

--- a/src/types/app-environment.ts
+++ b/src/types/app-environment.ts
@@ -1,12 +1,26 @@
+export interface AppEnvironmentVariableDto {
+  id: string;
+  key: string;
+  value: string;
+}
+
+export interface AppEnvironmentSecretDto {
+  id: string;
+  key: string;
+}
+
 export interface AppEnvironmentDto {
   id: string;
   appId: string;
   name: string;
+  appEnvironmentVariables?: AppEnvironmentVariableDto[];
+  appEnvironmentSecrets?: AppEnvironmentSecretDto[];
 }
 
 export interface FindAllAppEnvironmentsDto {
   appId: string;
   name?: string;
+  relations?: string;
   limit?: number;
   offset?: number;
 }
@@ -14,6 +28,7 @@ export interface FindAllAppEnvironmentsDto {
 export interface FindOneAppEnvironmentByIdDto {
   appId: string;
   id: string;
+  relations?: string;
 }
 
 export interface CreateAppEnvironmentDto {


### PR DESCRIPTION
## Description

Adds a way to read an environment's variables and secrets via the existing `relations` query-param convention (mirroring `deployments get`/`list`).

### `apps environments get`
- Always requests the `appEnvironmentVariables` and `appEnvironmentSecrets` relations.
- `--json` prints the full environment object including both relations.
- Human-readable output prints the environment table, followed by a variables table (`id`, `key`, `value`) and a secrets table (`id`, `key`), each with `id` as the first column.

### `apps environments list`
- Requests the relations only when `--json` is set, so the table output stays unchanged.
- The table output now prints a hint that variable keys/values and secret keys are only included with `--json`.

### Types & service
- Adds `AppEnvironmentVariableDto` (`id`, `key`, `value`) and `AppEnvironmentSecretDto` (`id`, `key`).
- Adds optional `appEnvironmentVariables` / `appEnvironmentSecrets` to `AppEnvironmentDto`.
- Adds `relations` passthrough to `findAll` and `findOneById`.

> [!NOTE]
> Requires backend support for the `appEnvironmentVariables` and `appEnvironmentSecrets` relations on `GET /environments/:id` (and the `?name=` list endpoint). The CLI change is inert until the API returns them.