### PR TITLE
feat(telemetry): add crash report notice and opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ The Capawesome Cloud CLI ships with command documentation that is accessible wit
 npx @capawesome/cli --help
 ```
 
+## Telemetry
+
+The Capawesome Cloud CLI sends crash reports to help us identify and fix bugs. No usage analytics are collected.
+
+To opt out, set the following environment variable:
+
+```bash
+export CAPAWESOME_TELEMETRY_DISABLED=1
+```
+
+Learn more in the [Telemetry documentation](https://capawesome.io/docs/cloud/cli/telemetry/).
+
 ## Development
 
 ### Getting Started

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import configService from '@/services/config.js';
+import telemetryService from '@/services/telemetry.js';
 import updateService from '@/services/update.js';
 import { getMessageFromUnknownError, UserError } from '@/utils/error.js';
 import { defineConfig, processConfig, ZliError } from '@robingenz/zli';
@@ -113,6 +114,10 @@ const captureException = async (error: unknown) => {
   if (error instanceof ZodError) {
     return;
   }
+  // Respect telemetry opt-out
+  if (!telemetryService.isEnabled()) {
+    return;
+  }
   const environment = await configService.getValueForKey('ENVIRONMENT');
   if (environment !== 'production') {
     return;
@@ -143,12 +148,16 @@ try {
     // Suggest opening an issue
     consola.log('If you think this is a bug, please open an issue at:');
     consola.log('  https://github.com/capawesome-team/cli/issues/new/choose');
+    // Show the telemetry notice
+    telemetryService.showNoticeIfNeeded();
     // Check for updates
     await updateService.checkForUpdate();
     // Exit with a non-zero code
     process.exit(1);
   }
 } finally {
+  // Show the telemetry notice
+  telemetryService.showNoticeIfNeeded();
   // Check for updates
   await updateService.checkForUpdate();
 }

--- a/src/services/telemetry.test.ts
+++ b/src/services/telemetry.test.ts
@@ -1,0 +1,88 @@
+import consola from 'consola';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isInteractive } from '@/utils/environment.js';
+import userConfig from '@/utils/user-config.js';
+import telemetryService from './telemetry.js';
+
+vi.mock('@/utils/environment.js');
+vi.mock('@/utils/user-config.js');
+vi.mock('consola');
+
+describe('telemetryService', () => {
+  const mockIsInteractive = vi.mocked(isInteractive);
+  const mockRead = vi.mocked(userConfig.read);
+  const mockWrite = vi.mocked(userConfig.write);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CAPAWESOME_TELEMETRY_DISABLED;
+    mockIsInteractive.mockReturnValue(true);
+    mockRead.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    delete process.env.CAPAWESOME_TELEMETRY_DISABLED;
+  });
+
+  describe('isEnabled', () => {
+    it('should be enabled by default', () => {
+      expect(telemetryService.isEnabled()).toBe(true);
+    });
+
+    it.each(['1', 'true', 'TRUE'])('should be disabled when CAPAWESOME_TELEMETRY_DISABLED is "%s"', (value) => {
+      process.env.CAPAWESOME_TELEMETRY_DISABLED = value;
+      expect(telemetryService.isEnabled()).toBe(false);
+    });
+
+    it('should stay enabled for other values', () => {
+      process.env.CAPAWESOME_TELEMETRY_DISABLED = '0';
+      expect(telemetryService.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('showNoticeIfNeeded', () => {
+    it('should show the notice once and persist the flag', () => {
+      mockRead.mockReturnValue({ token: 'abc' });
+
+      telemetryService.showNoticeIfNeeded();
+
+      expect(consola.info).toHaveBeenCalledOnce();
+      expect(mockWrite).toHaveBeenCalledWith({ token: 'abc', telemetryNoticeShown: true });
+    });
+
+    it('should not show the notice when it was already shown', () => {
+      mockRead.mockReturnValue({ telemetryNoticeShown: true });
+
+      telemetryService.showNoticeIfNeeded();
+
+      expect(consola.info).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('should not show the notice when telemetry is disabled', () => {
+      process.env.CAPAWESOME_TELEMETRY_DISABLED = '1';
+
+      telemetryService.showNoticeIfNeeded();
+
+      expect(consola.info).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('should not show the notice in non-interactive environments', () => {
+      mockIsInteractive.mockReturnValue(false);
+
+      telemetryService.showNoticeIfNeeded();
+
+      expect(consola.info).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when reading or writing the config fails', () => {
+      mockRead.mockImplementation(() => {
+        throw new Error('read failed');
+      });
+
+      expect(() => telemetryService.showNoticeIfNeeded()).not.toThrow();
+    });
+  });
+});

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,0 +1,40 @@
+import { isInteractive } from '@/utils/environment.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+
+const TELEMETRY_DISABLED_VALUES = ['1', 'true'];
+
+export interface TelemetryService {
+  isEnabled(): boolean;
+  showNoticeIfNeeded(): void;
+}
+
+class TelemetryServiceImpl implements TelemetryService {
+  isEnabled(): boolean {
+    const value = process.env.CAPAWESOME_TELEMETRY_DISABLED?.toLowerCase();
+    return !value || !TELEMETRY_DISABLED_VALUES.includes(value);
+  }
+
+  showNoticeIfNeeded(): void {
+    if (!this.isEnabled() || !isInteractive()) {
+      return;
+    }
+    try {
+      if (userConfig.read().telemetryNoticeShown) {
+        return;
+      }
+      consola.info(
+        'Capawesome CLI sends crash reports to help us fix bugs.\n' +
+          'To opt out: export CAPAWESOME_TELEMETRY_DISABLED=1\n' +
+          'Learn more: https://capawesome.io/docs/cloud/cli/telemetry/',
+      );
+      userConfig.write({ ...userConfig.read(), telemetryNoticeShown: true });
+    } catch {
+      // Never let the telemetry notice break the CLI.
+    }
+  }
+}
+
+const telemetryService: TelemetryService = new TelemetryServiceImpl();
+
+export default telemetryService;

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -20,7 +20,8 @@ class TelemetryServiceImpl implements TelemetryService {
       return;
     }
     try {
-      if (userConfig.read().telemetryNoticeShown) {
+      const config = userConfig.read();
+      if (config.telemetryNoticeShown) {
         return;
       }
       consola.info(
@@ -28,7 +29,7 @@ class TelemetryServiceImpl implements TelemetryService {
           'To opt out: export CAPAWESOME_TELEMETRY_DISABLED=1\n' +
           'Learn more: https://capawesome.io/docs/cloud/cli/telemetry/',
       );
-      userConfig.write({ ...userConfig.read(), telemetryNoticeShown: true });
+      userConfig.write({ ...config, telemetryNoticeShown: true });
     } catch {
       // Never let the telemetry notice break the CLI.
     }

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -5,6 +5,7 @@ import { readUser, writeUser } from 'rc9';
 
 export interface IUserConfig {
   token?: string;
+  telemetryNoticeShown?: boolean;
 }
 
 export interface UserConfig {


### PR DESCRIPTION
## Description

Adds a first-run telemetry notice and an opt-out mechanism for the crash reporting the CLI already sends via Sentry. No new data collection is introduced.

### Changes

- **New `telemetryService`** (`src/services/telemetry.ts`):
  - `isEnabled()` returns `false` when `CAPAWESOME_TELEMETRY_DISABLED` is `1`/`true`.
  - `showNoticeIfNeeded()` prints a one-time notice. It is suppressed when telemetry is disabled, in non-interactive/CI environments, or once already shown. Wrapped in try/catch so a config read/write failure can never break the CLI.
- **Opt-out wired into crash reporting** (`src/index.ts`): `captureException` now returns early when telemetry is disabled, so the env var truly stops reports.
- **Notice shown after the command runs** in both the success and error paths.
- **Persisted flag** `telemetryNoticeShown` added to the user config (`src/utils/user-config.ts`), written via read-merge-write so the stored token is preserved.
- **Tests** (`src/services/telemetry.test.ts`) covering enable/disable detection, show-once persistence, CI/non-interactive gating, and failure resilience.
- **README** documents the opt-out and links to the docs.

### Notes

- The notice is gated on `isInteractive()`, so it never clutters CI logs (where a fresh `~/.capawesome` would otherwise reprint it every run). CI users rely on the env var.
- Documentation lives in the docs repo and is handled separately.