### PR TITLE
feat(telemetry): attach user ID to crash reports

### DIFF
--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -78,6 +78,30 @@ describe('login', () => {
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
   });
 
+  it('should preserve other config fields and clear the previous user ID before sign-in', async () => {
+    const testToken = 'valid-token-123';
+    const options = { token: testToken };
+
+    mockUserConfig.read.mockReturnValue({ token: testToken, userId: 'previous-user', telemetryNoticeShown: true });
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/users/me')
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { id: 'user-123', email: 'test@example.com' });
+
+    await loginCommand.action(options, undefined);
+
+    // The previous user ID is dropped before the new user is confirmed, while other flags are preserved.
+    expect(mockUserConfig.write).toHaveBeenCalledWith({ telemetryNoticeShown: true, token: testToken });
+    // Once confirmed, the new user ID is stored alongside the preserved flags.
+    expect(mockUserConfig.write).toHaveBeenCalledWith({
+      telemetryNoticeShown: true,
+      token: testToken,
+      userId: 'user-123',
+    });
+    expect(scope.isDone()).toBe(true);
+  });
+
   it('should open the browser', async () => {
     const options = {};
 

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -73,6 +73,7 @@ describe('login', () => {
     await loginCommand.action(options, undefined);
 
     expect(mockUserConfig.write).toHaveBeenCalledWith({ token: testToken });
+    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: testToken, userId: 'user-123' });
     expect(scope.isDone()).toBe(true);
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
   });
@@ -112,6 +113,7 @@ describe('login', () => {
     expect(mockSessionCodesService.create).toHaveBeenCalled();
     expect(mockConsola.box).toHaveBeenCalledWith('Copy your one-time code: ABCD-1234');
     expect(mockOpen).toHaveBeenCalledWith(`${DEFAULT_CONSOLE_BASE_URL}/login/device`);
+    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: 'session-123', userId: 'user-123' });
     expect(scope.isDone()).toBe(true);
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
   });

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -86,15 +86,17 @@ export default defineCommand({
     }
     // Sign in with the provided token
     consola.start('Signing in...');
-    userConfig.write({
-      token: sessionIdOrToken,
-    });
+    // Drop the previous token and user ID but keep other flags,
+    // so a crash during sign-in isn't attributed to the previous account
+    const { token: _previousToken, userId: _previousUserId, ...persistentConfig } = userConfig.read();
+    userConfig.write({ ...persistentConfig, token: sessionIdOrToken });
     try {
       const user = await usersService.me();
-      userConfig.write({ token: sessionIdOrToken, userId: user.id });
+      userConfig.write({ ...persistentConfig, token: sessionIdOrToken, userId: user.id });
       consola.success(`Successfully signed in.`);
     } catch (error) {
-      userConfig.write({});
+      // Clear the credentials on failure while preserving the other flags
+      userConfig.write(persistentConfig);
       if (error instanceof AxiosError && error.response?.status === 401) {
         consola.error(
           `Invalid token. Please provide a valid token. You can create a token at ${consoleBaseUrl}/settings/tokens.`,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -90,7 +90,8 @@ export default defineCommand({
       token: sessionIdOrToken,
     });
     try {
-      await usersService.me();
+      const user = await usersService.me();
+      userConfig.write({ token: sessionIdOrToken, userId: user.id });
       consola.success(`Successfully signed in.`);
     } catch (error) {
       userConfig.write({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import configService from '@/services/config.js';
 import telemetryService from '@/services/telemetry.js';
 import updateService from '@/services/update.js';
 import { getMessageFromUnknownError, UserError } from '@/utils/error.js';
+import userConfig from '@/utils/user-config.js';
 import { defineConfig, processConfig, ZliError } from '@robingenz/zli';
 import * as Sentry from '@sentry/node';
 import { AxiosError } from 'axios';
@@ -126,6 +127,14 @@ const captureException = async (error: unknown) => {
     dsn: 'https://19f30f2ec4b91899abc33818568ceb42@o4507446340747264.ingest.de.sentry.io/4508506426966096',
     release: `capawesome-team-cli@${pkg.version}`,
   });
+  try {
+    const { userId } = userConfig.read();
+    if (userId) {
+      Sentry.setUser({ id: userId });
+    }
+  } catch {
+    // Still report the crash even if the user ID can't be read.
+  }
   if (process.argv.slice(2).length > 0) {
     Sentry.setTag('cli_command', process.argv.slice(2)[0]);
   }

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -5,6 +5,7 @@ import { readUser, writeUser } from 'rc9';
 
 export interface IUserConfig {
   token?: string;
+  userId?: string;
   telemetryNoticeShown?: boolean;
 }
 


### PR DESCRIPTION
## Description

Attaches the signed-in user's ID to Sentry crash reports so failures can be traced back to an account. The ID is stored locally at sign-in and only set on a report when present.

### Changes

- **Store the user ID on sign-in** (`src/commands/login.ts`): after `usersService.me()` succeeds, the resolved `user.id` is persisted alongside the token.
- **New `userId` field** in the user config (`src/utils/user-config.ts`).
- **Set the Sentry user** (`src/index.ts`): `captureException` reads the stored `userId` and calls `Sentry.setUser({ id: userId })` when present. Reading the config is wrapped in try/catch so a crash is still reported even if the read fails, and the user is skipped entirely when no ID is stored (for example in CI, where authentication uses a token environment variable).
- **Tests** (`src/commands/login.test.ts`): assert the user ID is stored in both the token and browser login flows.