### PR TITLE
feat: store authentication token in OS secure storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "0.7.0",
+        "@napi-rs/keyring": "1.3.0",
         "@robingenz/zli": "0.2.0",
         "@sentry/node": "8.55.0",
         "adm-zip": "0.5.16",
@@ -211,6 +212,240 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "0.7.0",
+    "@napi-rs/keyring": "1.3.0",
     "@robingenz/zli": "0.2.0",
     "@sentry/node": "8.55.0",
     "adm-zip": "0.5.16",

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -80,6 +80,31 @@ describe('login', () => {
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
   });
 
+  it('should preserve other config flags and replace the previous user ID', async () => {
+    const testToken = 'valid-token-123';
+    const options = { token: testToken };
+
+    mockCredentialStore.getToken.mockReturnValue(testToken);
+    mockUserConfig.read.mockReturnValue({
+      token: 'previous-token',
+      userId: 'previous-user',
+      telemetryNoticeShown: true,
+    });
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/users/me')
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(200, { id: 'user-123', email: 'test@example.com' });
+
+    await loginCommand.action(options, undefined);
+
+    // The previous user ID is dropped before the new account is confirmed.
+    expect(mockUserConfig.write).toHaveBeenNthCalledWith(1, { telemetryNoticeShown: true });
+    // The new user ID is stored while other flags are preserved.
+    expect(mockUserConfig.write).toHaveBeenNthCalledWith(2, { telemetryNoticeShown: true, userId: 'user-123' });
+    expect(scope.isDone()).toBe(true);
+  });
+
   it('should open the browser', async () => {
     const options = {};
 

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -2,6 +2,7 @@ import { DEFAULT_API_BASE_URL, DEFAULT_CONSOLE_BASE_URL } from '@/config/consts.
 import configService from '@/services/config.js';
 import sessionCodesService from '@/services/session-code.js';
 import sessionsService from '@/services/sessions.js';
+import credentialStore from '@/utils/credential-store.js';
 import { prompt } from '@/utils/prompt.js';
 import userConfig from '@/utils/user-config.js';
 import consola from 'consola';
@@ -12,6 +13,7 @@ import loginCommand from './login.js';
 
 // Mock dependencies
 vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/credential-store.js');
 vi.mock('@/services/session-code.js');
 vi.mock('@/services/sessions.js');
 vi.mock('@/services/config.js');
@@ -21,12 +23,10 @@ vi.mock('@/utils/prompt.js');
 vi.mock('@/utils/environment.js', () => ({
   isInteractive: () => true,
 }));
-vi.mock('@/utils/environment.js', () => ({
-  isInteractive: () => true,
-}));
 
 describe('login', () => {
   const mockUserConfig = vi.mocked(userConfig);
+  const mockCredentialStore = vi.mocked(credentialStore);
   const mockSessionCodesService = vi.mocked(sessionCodesService);
   const mockSessionsService = vi.mocked(sessionsService);
   const mockConfigService = vi.mocked(configService);
@@ -39,6 +39,9 @@ describe('login', () => {
 
     mockUserConfig.write.mockImplementation(() => {});
     mockUserConfig.read.mockReturnValue({});
+    mockCredentialStore.setToken.mockImplementation(() => {});
+    mockCredentialStore.deleteToken.mockImplementation(() => {});
+    mockCredentialStore.getToken.mockReturnValue(null);
 
     // Mock config service to return consistent URLs
     mockConfigService.getValueForKey.mockImplementation((key: string) => {
@@ -61,8 +64,8 @@ describe('login', () => {
     const testToken = 'valid-token-123';
     const options = { token: testToken };
 
-    // Mock userConfig.read to return our test token after it's written
-    mockUserConfig.read.mockReturnValue({ token: testToken });
+    // Mock credentialStore.getToken to return our test token after it's written
+    mockCredentialStore.getToken.mockReturnValue(testToken);
 
     // Set up nock to intercept the /v1/users/me request
     const scope = nock(DEFAULT_API_BASE_URL)
@@ -72,34 +75,9 @@ describe('login', () => {
 
     await loginCommand.action(options, undefined);
 
-    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: testToken });
-    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: testToken, userId: 'user-123' });
+    expect(mockCredentialStore.setToken).toHaveBeenCalledWith(testToken);
     expect(scope.isDone()).toBe(true);
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
-  });
-
-  it('should preserve other config fields and clear the previous user ID before sign-in', async () => {
-    const testToken = 'valid-token-123';
-    const options = { token: testToken };
-
-    mockUserConfig.read.mockReturnValue({ token: testToken, userId: 'previous-user', telemetryNoticeShown: true });
-
-    const scope = nock(DEFAULT_API_BASE_URL)
-      .get('/v1/users/me')
-      .matchHeader('Authorization', `Bearer ${testToken}`)
-      .reply(200, { id: 'user-123', email: 'test@example.com' });
-
-    await loginCommand.action(options, undefined);
-
-    // The previous user ID is dropped before the new user is confirmed, while other flags are preserved.
-    expect(mockUserConfig.write).toHaveBeenCalledWith({ telemetryNoticeShown: true, token: testToken });
-    // Once confirmed, the new user ID is stored alongside the preserved flags.
-    expect(mockUserConfig.write).toHaveBeenCalledWith({
-      telemetryNoticeShown: true,
-      token: testToken,
-      userId: 'user-123',
-    });
-    expect(scope.isDone()).toBe(true);
   });
 
   it('should open the browser', async () => {
@@ -116,8 +94,8 @@ describe('login', () => {
 
     mockSessionsService.create.mockResolvedValue({ id: 'session-123' });
 
-    // Mock userConfig.read to return the session token
-    mockUserConfig.read.mockReturnValue({ token: 'session-123' });
+    // Mock credentialStore.getToken to return the session token
+    mockCredentialStore.getToken.mockReturnValue('session-123');
 
     // Set up nock to intercept the /v1/users/me request
     const scope = nock(DEFAULT_API_BASE_URL)
@@ -137,7 +115,6 @@ describe('login', () => {
     expect(mockSessionCodesService.create).toHaveBeenCalled();
     expect(mockConsola.box).toHaveBeenCalledWith('Copy your one-time code: ABCD-1234');
     expect(mockOpen).toHaveBeenCalledWith(`${DEFAULT_CONSOLE_BASE_URL}/login/device`);
-    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: 'session-123', userId: 'user-123' });
     expect(scope.isDone()).toBe(true);
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed in.');
   });
@@ -157,8 +134,8 @@ describe('login', () => {
     const invalidToken = 'invalid-token';
     const options = { token: invalidToken };
 
-    // Mock userConfig.read to return our invalid token after it's written
-    mockUserConfig.read.mockReturnValue({ token: invalidToken });
+    // Mock credentialStore.getToken to return our invalid token after it's written
+    mockCredentialStore.getToken.mockReturnValue(invalidToken);
 
     // Set up nock to intercept the /v1/users/me request and return 401
     const scope = nock(DEFAULT_API_BASE_URL)
@@ -168,8 +145,8 @@ describe('login', () => {
 
     await expect(loginCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
 
-    expect(mockUserConfig.write).toHaveBeenCalledWith({ token: invalidToken });
-    expect(mockUserConfig.write).toHaveBeenCalledWith({}); // Clears token on error
+    expect(mockCredentialStore.setToken).toHaveBeenCalledWith(invalidToken);
+    expect(mockCredentialStore.deleteToken).toHaveBeenCalled(); // Clears token on error
     expect(scope.isDone()).toBe(true);
     expect(mockConsola.error).toHaveBeenCalledWith(
       `Invalid token. Please provide a valid token. You can create a token at ${DEFAULT_CONSOLE_BASE_URL}/settings/tokens.`,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import sessionsService from '@/services/sessions.js';
 import usersService from '@/services/users.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt } from '@/utils/prompt.js';
+import credentialStore from '@/utils/credential-store.js';
 import userConfig from '@/utils/user-config.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
 import { AxiosError } from 'axios';
@@ -86,17 +87,18 @@ export default defineCommand({
     }
     // Sign in with the provided token
     consola.start('Signing in...');
-    // Drop the previous token and user ID but keep other flags,
+    // Drop the previous user ID but keep other flags,
     // so a crash during sign-in isn't attributed to the previous account
     const { token: _previousToken, userId: _previousUserId, ...persistentConfig } = userConfig.read();
-    userConfig.write({ ...persistentConfig, token: sessionIdOrToken });
+    userConfig.write(persistentConfig);
+    credentialStore.setToken(sessionIdOrToken);
     try {
       const user = await usersService.me();
-      userConfig.write({ ...persistentConfig, token: sessionIdOrToken, userId: user.id });
+      userConfig.write({ ...persistentConfig, userId: user.id });
       consola.success(`Successfully signed in.`);
     } catch (error) {
       // Clear the credentials on failure while preserving the other flags
-      userConfig.write(persistentConfig);
+      credentialStore.deleteToken();
       if (error instanceof AxiosError && error.response?.status === 401) {
         consola.error(
           `Invalid token. Please provide a valid token. You can create a token at ${consoleBaseUrl}/settings/tokens.`,

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
 import authorizationService from '@/services/authorization-service.js';
+import credentialStore from '@/utils/credential-store.js';
 import userConfig from '@/utils/user-config.js';
 import consola from 'consola';
 import nock from 'nock';
@@ -8,18 +9,22 @@ import logoutCommand from './logout.js';
 
 // Mock dependencies
 vi.mock('@/services/authorization-service.js');
+vi.mock('@/utils/credential-store.js');
 vi.mock('@/utils/user-config.js');
 vi.mock('consola');
 
 describe('logout', () => {
   const mockAuthorizationService = vi.mocked(authorizationService);
+  const mockCredentialStore = vi.mocked(credentialStore);
   const mockUserConfig = vi.mocked(userConfig);
   const mockConsola = vi.mocked(consola);
 
   beforeEach(() => {
     vi.clearAllMocks();
 
+    mockCredentialStore.deleteToken.mockImplementation(() => {});
     mockUserConfig.write.mockImplementation(() => {});
+    mockUserConfig.read.mockReturnValue({});
   });
 
   afterEach(() => {
@@ -27,7 +32,7 @@ describe('logout', () => {
     vi.restoreAllMocks();
   });
 
-  it('should delete session and clear user config with session token', async () => {
+  it('should delete session and clear credentials with session token', async () => {
     const sessionToken = 'session-123';
     mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue(sessionToken);
 
@@ -37,18 +42,27 @@ describe('logout', () => {
     await logoutCommand.action({}, undefined);
 
     expect(scope.isDone()).toBe(true);
-    expect(mockUserConfig.write).toHaveBeenCalledWith({});
+    expect(mockCredentialStore.deleteToken).toHaveBeenCalled();
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed out.');
   });
 
-  it('should only clear user config with API token', async () => {
+  it('should only clear credentials with API token', async () => {
     const apiToken = 'ca_abc123';
     mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue(apiToken);
 
     await logoutCommand.action({}, undefined);
 
-    expect(mockUserConfig.write).toHaveBeenCalledWith({});
+    expect(mockCredentialStore.deleteToken).toHaveBeenCalled();
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed out.');
+  });
+
+  it('should clear the user ID but preserve other flags', async () => {
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('ca_abc123');
+    mockUserConfig.read.mockReturnValue({ token: 'ca_abc123', userId: 'user-1', telemetryNoticeShown: true });
+
+    await logoutCommand.action({}, undefined);
+
+    expect(mockUserConfig.write).toHaveBeenCalledWith({ telemetryNoticeShown: true });
   });
 
   it('should handle no token gracefully', async () => {
@@ -56,7 +70,7 @@ describe('logout', () => {
 
     await logoutCommand.action({}, undefined);
 
-    expect(mockUserConfig.write).toHaveBeenCalledWith({});
+    expect(mockCredentialStore.deleteToken).toHaveBeenCalled();
     expect(mockConsola.success).toHaveBeenCalledWith('Successfully signed out.');
   });
 });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -2,6 +2,7 @@ import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
 import authorizationService from '@/services/authorization-service.js';
 import sessionsService from '@/services/sessions.js';
+import credentialStore from '@/utils/credential-store.js';
 import userConfig from '@/utils/user-config.js';
 
 export default defineCommand({
@@ -11,7 +12,10 @@ export default defineCommand({
     if (token && !token.startsWith('ca_')) {
       await sessionsService.delete({ id: token }).catch(() => {});
     }
-    userConfig.write({});
+    credentialStore.deleteToken();
+    // Clear the user ID but keep other flags (e.g. the telemetry notice).
+    const { token: _token, userId: _userId, ...persistentConfig } = userConfig.read();
+    userConfig.write(persistentConfig);
     consola.success('Successfully signed out.');
   },
 });

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -1,14 +1,14 @@
 import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
-import userConfig from '@/utils/user-config.js';
+import authorizationService from '@/services/authorization-service.js';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import whoamiCommand from './whoami.js';
 
 // Mock only the dependencies we need to control
-vi.mock('@/utils/user-config.js');
+vi.mock('@/services/authorization-service.js');
 
 describe('whoami', () => {
-  const mockUserConfig = vi.mocked(userConfig);
+  const mockAuthorizationService = vi.mocked(authorizationService);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -24,8 +24,8 @@ describe('whoami', () => {
   it('should send Bearer token in Authorization header when checking current user', async () => {
     const testToken = 'user-token-456';
 
-    // Mock userConfig.read to return our test token
-    mockUserConfig.read.mockReturnValue({ token: testToken });
+    // Mock the authorization service to return our test token
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue(testToken);
 
     // Set up nock to intercept the /v1/users/me request
     const scope = nock(DEFAULT_API_BASE_URL)

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,5 +1,5 @@
+import authorizationService from '@/services/authorization-service.js';
 import usersService from '@/services/users.js';
-import userConfig from '@/utils/user-config.js';
 import { defineCommand } from '@robingenz/zli';
 import { AxiosError } from 'axios';
 import consola from 'consola';
@@ -7,7 +7,7 @@ import consola from 'consola';
 export default defineCommand({
   description: 'Show current user',
   action: async (options, args) => {
-    const { token } = userConfig.read();
+    const token = authorizationService.getCurrentAuthorizationToken();
     if (token) {
       try {
         const user = await usersService.me();

--- a/src/services/authorization-service.ts
+++ b/src/services/authorization-service.ts
@@ -1,10 +1,10 @@
-import userConfig, { UserConfig } from '@/utils/user-config.js';
+import credentialStore, { CredentialStore } from '@/utils/credential-store.js';
 
 export interface AuthorizationService {
   /**
    * Returns the current authorization token.
-   * If running in CI, it will return the CAPAWESOME_TOKEN environment variable.
-   * If not running in CI, it will return the token from the local user config.
+   * It prefers the token from the secure credential store and falls back to the
+   * CAPAWESOME_CLOUD_TOKEN and CAPAWESOME_TOKEN environment variables.
    * If no token is found, it will return null.
    * @returns The current authorization token or null.
    */
@@ -18,15 +18,15 @@ export interface AuthorizationService {
 }
 
 class AuthorizationServiceImpl implements AuthorizationService {
-  private readonly userConfig: UserConfig;
+  private readonly credentialStore: CredentialStore;
 
-  constructor(userConfig: UserConfig) {
-    this.userConfig = userConfig;
+  constructor(credentialStore: CredentialStore) {
+    this.credentialStore = credentialStore;
   }
 
   getCurrentAuthorizationToken(): string | null {
     const token =
-      this.userConfig.read().token || process.env.CAPAWESOME_CLOUD_TOKEN || process.env.CAPAWESOME_TOKEN || null;
+      this.credentialStore.getToken() || process.env.CAPAWESOME_CLOUD_TOKEN || process.env.CAPAWESOME_TOKEN || null;
     // Trim to remove newline characters that may be included when pasting a token,
     // which would cause an invalid character error in the Authorization header.
     const trimmedToken = token?.trim();
@@ -38,6 +38,6 @@ class AuthorizationServiceImpl implements AuthorizationService {
   }
 }
 
-const authorizationService: AuthorizationService = new AuthorizationServiceImpl(userConfig);
+const authorizationService: AuthorizationService = new AuthorizationServiceImpl(credentialStore);
 
 export default authorizationService;

--- a/src/utils/credential-store.test.ts
+++ b/src/utils/credential-store.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetPassword, mockSetPassword, mockDeletePassword, mockRead, mockWrite } = vi.hoisted(() => ({
+  mockGetPassword: vi.fn(),
+  mockSetPassword: vi.fn(),
+  mockDeletePassword: vi.fn(),
+  mockRead: vi.fn(),
+  mockWrite: vi.fn(),
+}));
+
+vi.mock('@napi-rs/keyring', () => ({
+  Entry: vi.fn(function () {
+    return {
+      getPassword: mockGetPassword,
+      setPassword: mockSetPassword,
+      deletePassword: mockDeletePassword,
+    };
+  }),
+}));
+
+vi.mock('@/utils/user-config.js', () => ({
+  default: { read: mockRead, write: mockWrite },
+}));
+
+const loadCredentialStore = async () => {
+  const module = await import('./credential-store.js');
+  return module.default;
+};
+
+describe('credentialStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockRead.mockReturnValue({});
+  });
+
+  describe('when the keyring is available', () => {
+    beforeEach(() => {
+      mockGetPassword.mockReturnValue(null);
+    });
+
+    it('should return the token from the keyring', async () => {
+      mockGetPassword.mockReturnValue('keyring-token');
+      const credentialStore = await loadCredentialStore();
+
+      expect(credentialStore.getToken()).toBe('keyring-token');
+    });
+
+    it('should return null when no token is stored', async () => {
+      const credentialStore = await loadCredentialStore();
+
+      expect(credentialStore.getToken()).toBeNull();
+    });
+
+    it('should migrate a plaintext token from the config file into the keyring', async () => {
+      mockRead.mockReturnValue({ token: 'file-token', userId: 'user-1' });
+      const credentialStore = await loadCredentialStore();
+
+      expect(credentialStore.getToken()).toBe('file-token');
+      expect(mockSetPassword).toHaveBeenCalledWith('file-token');
+      expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1' });
+    });
+
+    it('should store the token in the keyring and strip the plaintext copy', async () => {
+      mockRead.mockReturnValue({ token: 'old-token', userId: 'user-1' });
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.setToken('new-token');
+
+      expect(mockSetPassword).toHaveBeenCalledWith('new-token');
+      expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1' });
+    });
+
+    it('should delete the token from the keyring', async () => {
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.deleteToken();
+
+      expect(mockDeletePassword).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the keyring is unavailable', () => {
+    beforeEach(() => {
+      mockGetPassword.mockImplementation(() => {
+        throw new Error('no keyring backend');
+      });
+    });
+
+    it('should return the token from the config file', async () => {
+      mockRead.mockReturnValue({ token: 'file-token' });
+      const credentialStore = await loadCredentialStore();
+
+      expect(credentialStore.getToken()).toBe('file-token');
+      expect(mockSetPassword).not.toHaveBeenCalled();
+    });
+
+    it('should store the token in the config file while preserving other fields', async () => {
+      mockRead.mockReturnValue({ userId: 'user-1' });
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.setToken('file-token');
+
+      expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1', token: 'file-token' });
+      expect(mockSetPassword).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/credential-store.ts
+++ b/src/utils/credential-store.ts
@@ -1,0 +1,109 @@
+import userConfig from '@/utils/user-config.js';
+import { Entry } from '@napi-rs/keyring';
+
+const SERVICE_NAME = 'capawesome-cli';
+const ACCOUNT_NAME = 'token';
+
+export interface CredentialStore {
+  /**
+   * Returns the stored authentication token or null if none is stored.
+   */
+  getToken(): string | null;
+  /**
+   * Stores the authentication token.
+   */
+  setToken(token: string): void;
+  /**
+   * Removes the stored authentication token.
+   */
+  deleteToken(): void;
+}
+
+/**
+ * Stores the authentication token in the operating system's secure storage
+ * (macOS Keychain, Windows Credential Manager, Linux Secret Service) when
+ * available and falls back to the plaintext user config file otherwise
+ * (e.g. headless CI environments without a keyring backend).
+ */
+class CredentialStoreImpl implements CredentialStore {
+  private keyringAvailable: boolean | null = null;
+
+  getToken(): string | null {
+    if (!this.isKeyringAvailable()) {
+      return userConfig.read().token ?? null;
+    }
+    const token = this.createEntry().getPassword();
+    if (token) {
+      return token;
+    }
+    return this.migrateFileToken();
+  }
+
+  setToken(token: string): void {
+    if (!this.isKeyringAvailable()) {
+      this.writeFileToken(token);
+      return;
+    }
+    this.createEntry().setPassword(token);
+    this.clearFileToken();
+  }
+
+  deleteToken(): void {
+    if (this.isKeyringAvailable()) {
+      try {
+        this.createEntry().deletePassword();
+      } catch {
+        // Ignore errors when there is no credential to delete.
+      }
+    }
+    this.clearFileToken();
+  }
+
+  private createEntry(): Entry {
+    return new Entry(SERVICE_NAME, ACCOUNT_NAME);
+  }
+
+  private isKeyringAvailable(): boolean {
+    if (this.keyringAvailable === null) {
+      try {
+        // Probe the backend with a read. This throws if no keyring backend is
+        // available, but returns null for a missing credential.
+        this.createEntry().getPassword();
+        this.keyringAvailable = true;
+      } catch {
+        this.keyringAvailable = false;
+      }
+    }
+    return this.keyringAvailable;
+  }
+
+  /**
+   * Moves a token stored in the plaintext config file into the keyring and
+   * removes the plaintext copy. Returns the migrated token or null.
+   */
+  private migrateFileToken(): string | null {
+    const fileToken = userConfig.read().token;
+    if (!fileToken) {
+      return null;
+    }
+    this.setToken(fileToken);
+    return fileToken;
+  }
+
+  private writeFileToken(token: string): void {
+    const config = userConfig.read();
+    userConfig.write({ ...config, token });
+  }
+
+  private clearFileToken(): void {
+    const { token, ...rest } = userConfig.read();
+    if (token === undefined) {
+      return;
+    }
+    userConfig.write(rest);
+  }
+}
+
+const credentialStore: CredentialStore = new CredentialStoreImpl();
+
+export default credentialStore;


### PR DESCRIPTION
## Summary

Stores the authentication token in the operating system's secure storage instead of a plaintext file. Uses the OS-native credential store (macOS Keychain, Windows Credential Manager, Linux Secret Service) via `@napi-rs/keyring`, with a plaintext-file fallback for headless/CI environments that have no keyring backend.

## Changes

- Add `CredentialStore` abstraction (`src/utils/credential-store.ts`):
  - Uses the OS keychain when available; probes once and falls back to the `~/.capawesome` config file otherwise.
  - Silently migrates an existing plaintext token into the keychain on first read and strips the file copy.
- `authorization-service.ts` now reads the token from the credential store first, then the `CAPAWESOME_CLOUD_TOKEN` / `CAPAWESOME_TOKEN` environment variables (env priority unchanged).
- `login` writes the token via the credential store; the non-secret `userId` stays in the config file.
- `logout` deletes the token from the credential store and clears `userId`, while preserving other flags (e.g. the telemetry notice) instead of wiping the whole file.
- `whoami` now resolves the token through the authorization service, so it also recognizes keychain- and environment-stored tokens.

## Notes

- The security boundary is the user account: encryption at rest and reduced incidental exposure, not isolation from same-user processes.
- The plaintext-file fallback keeps CI and keyring-less Linux environments working.

## Testing

- `npm test` (179 tests pass)
- `tsc --noEmit` clean
- Verified end-to-end against the macOS Keychain (`whoami` resolves the stored token)