### PR TITLE
fix(login): fall back to file storage when keyring write fails

### DIFF
--- a/src/utils/credential-store.test.ts
+++ b/src/utils/credential-store.test.ts
@@ -104,6 +104,18 @@ describe('credentialStore', () => {
 
       expect(mockDeletePassword).toHaveBeenCalled();
     });
+
+    it('should not read a stale keyring token after a keyring delete failure', async () => {
+      mockGetPassword.mockReturnValue('stale-keyring-token');
+      mockDeletePassword.mockImplementation(() => {
+        throw new Error('Platform failure: Unknown(38)');
+      });
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.deleteToken();
+
+      expect(credentialStore.getToken()).toBeNull();
+    });
   });
 
   describe('when the keyring is unavailable', () => {

--- a/src/utils/credential-store.test.ts
+++ b/src/utils/credential-store.test.ts
@@ -71,6 +71,19 @@ describe('credentialStore', () => {
       expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1' });
     });
 
+    it('should fall back to the config file when the keyring write fails', async () => {
+      mockRead.mockReturnValue({ userId: 'user-1' });
+      mockSetPassword.mockImplementation(() => {
+        throw new Error('Platform failure: Unknown(38)');
+      });
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.setToken('new-token');
+
+      expect(mockSetPassword).toHaveBeenCalledWith('new-token');
+      expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1', token: 'new-token' });
+    });
+
     it('should delete the token from the keyring', async () => {
       const credentialStore = await loadCredentialStore();
 

--- a/src/utils/credential-store.test.ts
+++ b/src/utils/credential-store.test.ts
@@ -34,7 +34,7 @@ describe('credentialStore', () => {
     mockRead.mockReturnValue({});
   });
 
-  describe('when the keyring is available', () => {
+  describe('when the keyring works', () => {
     beforeEach(() => {
       mockGetPassword.mockReturnValue(null);
     });
@@ -84,6 +84,19 @@ describe('credentialStore', () => {
       expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1', token: 'new-token' });
     });
 
+    it('should read the file token after a keyring write failure even when a stale keyring token exists', async () => {
+      mockGetPassword.mockReturnValue('stale-keyring-token');
+      mockSetPassword.mockImplementation(() => {
+        throw new Error('Platform failure: Unknown(38)');
+      });
+      mockRead.mockReturnValue({ token: 'new-token' });
+      const credentialStore = await loadCredentialStore();
+
+      credentialStore.setToken('new-token');
+
+      expect(credentialStore.getToken()).toBe('new-token');
+    });
+
     it('should delete the token from the keyring', async () => {
       const credentialStore = await loadCredentialStore();
 
@@ -95,9 +108,12 @@ describe('credentialStore', () => {
 
   describe('when the keyring is unavailable', () => {
     beforeEach(() => {
-      mockGetPassword.mockImplementation(() => {
+      const throwNoBackend = () => {
         throw new Error('no keyring backend');
-      });
+      };
+      mockGetPassword.mockImplementation(throwNoBackend);
+      mockSetPassword.mockImplementation(throwNoBackend);
+      mockDeletePassword.mockImplementation(throwNoBackend);
     });
 
     it('should return the token from the config file', async () => {
@@ -105,7 +121,6 @@ describe('credentialStore', () => {
       const credentialStore = await loadCredentialStore();
 
       expect(credentialStore.getToken()).toBe('file-token');
-      expect(mockSetPassword).not.toHaveBeenCalled();
     });
 
     it('should store the token in the config file while preserving other fields', async () => {
@@ -115,7 +130,14 @@ describe('credentialStore', () => {
       credentialStore.setToken('file-token');
 
       expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1', token: 'file-token' });
-      expect(mockSetPassword).not.toHaveBeenCalled();
+    });
+
+    it('should clear the file token without throwing when deleting', async () => {
+      mockRead.mockReturnValue({ token: 'file-token', userId: 'user-1' });
+      const credentialStore = await loadCredentialStore();
+
+      expect(() => credentialStore.deleteToken()).not.toThrow();
+      expect(mockWrite).toHaveBeenCalledWith({ userId: 'user-1' });
     });
   });
 });

--- a/src/utils/credential-store.ts
+++ b/src/utils/credential-store.ts
@@ -26,38 +26,42 @@ export interface CredentialStore {
  * (e.g. headless CI environments without a keyring backend).
  */
 class CredentialStoreImpl implements CredentialStore {
-  private keyringAvailable: boolean | null = null;
+  // Set once any keyring operation fails (e.g. a headless CI environment with a
+  // present but unusable Secret Service backend). From then on the file token is
+  // the single source of truth for the rest of the process, so reads don't
+  // return a stale keyring token after a failed write.
+  private keyringDisabled = false;
 
   getToken(): string | null {
-    if (!this.isKeyringAvailable()) {
-      return userConfig.read().token ?? null;
+    if (!this.keyringDisabled) {
+      try {
+        const token = this.createEntry().getPassword();
+        if (token) {
+          return token;
+        }
+        return this.migrateFileToken();
+      } catch {
+        this.keyringDisabled = true;
+      }
     }
-    const token = this.createEntry().getPassword();
-    if (token) {
-      return token;
-    }
-    return this.migrateFileToken();
+    return userConfig.read().token ?? null;
   }
 
   setToken(token: string): void {
-    if (!this.isKeyringAvailable()) {
-      this.writeFileToken(token);
-      return;
+    if (!this.keyringDisabled) {
+      try {
+        this.createEntry().setPassword(token);
+        this.clearFileToken();
+        return;
+      } catch {
+        this.keyringDisabled = true;
+      }
     }
-    try {
-      this.createEntry().setPassword(token);
-    } catch {
-      // The keyring read-probe can succeed while a write fails (e.g. a headless
-      // CI environment with a present but unusable Secret Service backend), so
-      // fall back to file storage instead of crashing.
-      this.writeFileToken(token);
-      return;
-    }
-    this.clearFileToken();
+    this.writeFileToken(token);
   }
 
   deleteToken(): void {
-    if (this.isKeyringAvailable()) {
+    if (!this.keyringDisabled) {
       try {
         this.createEntry().deletePassword();
       } catch {
@@ -69,20 +73,6 @@ class CredentialStoreImpl implements CredentialStore {
 
   private createEntry(): Entry {
     return new Entry(SERVICE_NAME, ACCOUNT_NAME);
-  }
-
-  private isKeyringAvailable(): boolean {
-    if (this.keyringAvailable === null) {
-      try {
-        // Probe the backend with a read. This throws if no keyring backend is
-        // available, but returns null for a missing credential.
-        this.createEntry().getPassword();
-        this.keyringAvailable = true;
-      } catch {
-        this.keyringAvailable = false;
-      }
-    }
-    return this.keyringAvailable;
   }
 
   /**

--- a/src/utils/credential-store.ts
+++ b/src/utils/credential-store.ts
@@ -65,7 +65,10 @@ class CredentialStoreImpl implements CredentialStore {
       try {
         this.createEntry().deletePassword();
       } catch {
-        // Ignore errors when there is no credential to delete.
+        // The deletion throws when there is no credential to delete, but also
+        // when the keyring cannot be mutated. Disable the keyring so a stale
+        // token can't be read back after the file token has been cleared.
+        this.keyringDisabled = true;
       }
     }
     this.clearFileToken();

--- a/src/utils/credential-store.ts
+++ b/src/utils/credential-store.ts
@@ -44,7 +44,15 @@ class CredentialStoreImpl implements CredentialStore {
       this.writeFileToken(token);
       return;
     }
-    this.createEntry().setPassword(token);
+    try {
+      this.createEntry().setPassword(token);
+    } catch {
+      // The keyring read-probe can succeed while a write fails (e.g. a headless
+      // CI environment with a present but unusable Secret Service backend), so
+      // fall back to file storage instead of crashing.
+      this.writeFileToken(token);
+      return;
+    }
     this.clearFileToken();
   }
 


### PR DESCRIPTION
## Problem

Running `login` in headless CI environments (e.g. CircleCI on Ubuntu) could crash with `Platform failure: Unknown(38)` thrown by `@napi-rs/keyring`.

The `CredentialStoreImpl` decides whether the keyring is available by probing it with a **read** (`getPassword`). In some environments that read succeeds (a Secret Service backend is present) while the subsequent **write** (`setPassword`) fails because the backend is not actually usable. In that case `setToken` skipped the file fallback and threw, crashing the command.

## Fix

Wrap the keyring write in `setToken` with a try/catch. When `setPassword` throws, fall back to plaintext file storage instead of crashing — mirroring the existing fallback behavior used elsewhere in the store.

## Tests

Added a test covering the case where the read-probe succeeds but the keyring write throws, asserting the token is persisted to the config file while preserving other fields.