### PR TITLE
fix: correct success message when using `--detached`

### DIFF
--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -457,7 +457,7 @@ export default defineCommand({
         consola.info(`Build ID: ${response.id}`);
         consola.info(`Build Number: ${response.numberAsString}`);
         consola.info(`Build URL: ${DEFAULT_CONSOLE_BASE_URL}/apps/${appId}/builds/${response.id}`);
-        consola.success(`Build completed successfully.`);
+        consola.success('Build started successfully.');
       }
     }
 


### PR DESCRIPTION
## What

`apps:builds:create --detached` printed `Build completed successfully.` even though the build had only been created and was still running. It now prints `Build started successfully.` instead.