### PR TITLE
fix: run deployment before `--json` output in `apps:builds:create`

### DIFF
--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -480,6 +480,16 @@ export default defineCommand({
         }
       }
 
+      // Create deployment if channel or destination is set
+      if (options.channel || options.destination) {
+        await (
+          await import('@/commands/apps/deployments/create.js').then((mod) => mod.default)
+        ).action(
+          { appId, buildId: response.id, channel: options.channel, destination: options.destination },
+          undefined,
+        );
+      }
+
       // Output JSON if json flag is set
       if (json) {
         console.log(
@@ -512,13 +522,6 @@ export default defineCommand({
         consola.info(`Build URL: ${DEFAULT_CONSOLE_BASE_URL}/apps/${appId}/builds/${response.id}`);
         consola.success('Build started successfully.');
       }
-    }
-
-    // Create deployment if channel or destination is set
-    if (options.channel || options.destination) {
-      await (
-        await import('@/commands/apps/deployments/create.js').then((mod) => mod.default)
-      ).action({ appId, buildId: response.id, channel: options.channel, destination: options.destination }, undefined);
     }
   }),
 });


### PR DESCRIPTION
In `apps:builds:create`, the deployment delegation (triggered by `--channel` or `--destination`) ran after the `--json` output block, so the delegated `apps:deployments:create` output landed on stdout after the JSON document. Consumers that parse the JSON tail of the command output received invalid input when `--json` was combined with `--channel` or `--destination`.

The deployment delegation now runs inside the wait-for-completion branch, after the share step and before the JSON output, so the JSON document is always the last thing written to stdout. Since `--detached` is already rejected in combination with `--channel` or `--destination`, the detached branch does not need the deployment block.

Close #180