### PR TITLE
fix(deps): update `systeminformation` to `5.31.17`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "open": "10.2.0",
         "rc9": "2.1.2",
         "semver": "7.6.3",
-        "systeminformation": "5.31.6",
+        "systeminformation": "5.31.17",
         "zod": "4.0.17"
       },
       "bin": {
@@ -151,6 +151,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3704,9 +3705,9 @@
       "license": "MIT"
     },
     "node_modules/systeminformation": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
-      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
+      "version": "5.31.17",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.17.tgz",
+      "integrity": "sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "open": "10.2.0",
     "rc9": "2.1.2",
     "semver": "7.6.3",
-    "systeminformation": "5.31.6",
+    "systeminformation": "5.31.17",
     "zod": "4.0.17"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates `systeminformation` from `5.31.6` to `5.31.17` to resolve a high-severity OS command injection vulnerability in `networkInterfaces()` on Linux ([GHSA-5xpp-75jx-m839](https://github.com/advisories/GHSA-5xpp-75jx-m839)).

`npm audit` reports 0 vulnerabilities after this update.