### PR TITLE
fix(deps): update `adm-zip` to `0.6.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@napi-rs/keyring": "1.3.0",
         "@robingenz/zli": "0.2.0",
         "@sentry/node": "10.58.0",
-        "adm-zip": "0.5.16",
+        "adm-zip": "0.6.0",
         "axios": "1.16.0",
         "axios-retry": "4.5.0",
         "c12": "3.3.3",
@@ -45,7 +45,6 @@
       "devDependencies": {
         "@ionic/prettier-config": "4.0.0",
         "@sentry/cli": "2.52.0",
-        "@types/adm-zip": "0.5.7",
         "@types/mime": "3.0.4",
         "@types/node": "24.2.1",
         "@types/semver": "7.5.8",
@@ -1315,16 +1314,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-      "integrity": "sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1561,12 +1550,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@napi-rs/keyring": "1.3.0",
     "@robingenz/zli": "0.2.0",
     "@sentry/node": "10.58.0",
-    "adm-zip": "0.5.16",
+    "adm-zip": "0.6.0",
     "axios": "1.16.0",
     "axios-retry": "4.5.0",
     "c12": "3.3.3",
@@ -78,7 +78,6 @@
   "devDependencies": {
     "@ionic/prettier-config": "4.0.0",
     "@sentry/cli": "2.52.0",
-    "@types/adm-zip": "0.5.7",
     "@types/mime": "3.0.4",
     "@types/node": "24.2.1",
     "@types/semver": "7.5.8",


### PR DESCRIPTION
## Changes

Updates `adm-zip` from `0.5.16` to `0.6.0` and removes `@types/adm-zip`, since `0.6.0` ships bundled TypeScript type definitions.

## Changelog review

- **Security**: Fixes CVE-2026-39244 — a crafted archive declaring a huge uncompressed size could force an unbounded `Buffer.alloc` and OOM the process.
- **Behavior changes** (both extraction-only, not used by this CLI, which only creates zips):
  - `extractEntryTo(..., maintainEntryPath: false)` now preserves subdirectories instead of flattening them.
  - A failed `utimes` no longer aborts extraction.
- **Node**: Minimum is now `>= 14`; this project already requires `>= 20`.
- **Bonus**: Fixes infinite recursion on symlink loops in `addLocalFolder`, which `zipFolder` uses directly.

## Verification

- Build, typecheck, and all 201 tests pass.
- Smoke-tested the exact usage pattern (`addLocalFolder` → `entry.attr = 0` → `toBuffer` → round-trip) against `0.6.0`.

Supersedes #189.