### PR TITLE
feat(apps): add commands to manage native configurations

### DIFF
--- a/src/commands/apps/builds/create.test.ts
+++ b/src/commands/apps/builds/create.test.ts
@@ -130,6 +130,30 @@ describe('apps-builds-create', () => {
     );
   });
 
+  it('should reject --configuration combined with a platform that does not support it', async () => {
+    const options = { appId, platform: 'web' as const, gitRef: 'main', configuration: 'production' };
+
+    await expect(createCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
+
+    expect(mockConsola.error).toHaveBeenCalledWith(
+      'The --configuration flag can only be used with the android and ios platforms.',
+    );
+  });
+
+  it.each(['android', 'ios'] as const)('should accept --configuration with the %s platform', async (platform) => {
+    const options = { appId, platform, gitRef: 'main', configuration: 'production', detached: true };
+
+    const buildScope = nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/builds`, (body) => body.appConfigurationName === 'production')
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: buildId, jobId: 'job-1', numberAsString: '42' });
+
+    await createCommand.action(options, undefined);
+
+    expect(buildScope.isDone()).toBe(true);
+    expect(mockConsola.error).not.toHaveBeenCalled();
+  });
+
   it('should reject a non-positive shareExpiresInDays value', () => {
     const schema = createCommand.options?.schema;
 

--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CONSOLE_BASE_URL } from '@/config/consts.js';
 import appBuildSourcesService from '@/services/app-build-sources.js';
 import appBuildsService from '@/services/app-builds.js';
 import appCertificatesService from '@/services/app-certificates.js';
+import appConfigurationsService from '@/services/app-configurations.js';
 import appEnvironmentsService from '@/services/app-environments.js';
 import appsService from '@/services/apps.js';
 import { AppBuildArtifactDto } from '@/types/app-build.js';
@@ -44,6 +45,7 @@ export default defineCommand({
         .describe('App ID to create the build for.'),
       certificate: z.string().optional().describe('The name of the certificate to use for the build.'),
       channel: z.string().optional().describe('The name of the channel to deploy to (Web only).'),
+      configuration: z.string().optional().describe('The name of the native configuration (Android/iOS only).'),
       destination: z.string().optional().describe('The name of the destination to deploy to (Android/iOS only).'),
       detached: z
         .boolean()
@@ -110,7 +112,19 @@ export default defineCommand({
     { y: 'yes' },
   ),
   action: withAuth(async (options) => {
-    let { appId, platform, type, gitRef, environment, certificate, json, stack, path: sourcePath, url } = options;
+    let {
+      appId,
+      platform,
+      type,
+      gitRef,
+      environment,
+      certificate,
+      configuration,
+      json,
+      stack,
+      path: sourcePath,
+      url,
+    } = options;
 
     // Validate that detached flag cannot be used with artifact flags
     if (options.detached && (options.apk || options.aab || options.ipa || options.zip)) {
@@ -279,6 +293,13 @@ export default defineCommand({
       process.exit(1);
     }
 
+    // Validate that configuration is only used with the platforms that support it
+    const supportsConfiguration = platform === 'android' || platform === 'ios';
+    if (options.configuration && !supportsConfiguration) {
+      consola.error('The --configuration flag can only be used with the android and ios platforms.');
+      process.exit(1);
+    }
+
     // Prompt for environment if not provided
     if (!environment && !options.yes && isInteractive()) {
       // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
@@ -316,6 +337,27 @@ export default defineCommand({
           certificate = await prompt('Select the certificate for the build:', {
             type: 'select',
             options: certificates.map((cert) => ({ label: cert.name, value: cert.name })),
+          });
+        }
+      }
+    }
+
+    // Prompt for configuration if not provided
+    if (!configuration && supportsConfiguration && !options.yes && isInteractive()) {
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      const selectConfiguration = await prompt('Do you want to select a native configuration?', {
+        type: 'confirm',
+        initial: false,
+      });
+      if (selectConfiguration) {
+        const configurations = await appConfigurationsService.findAll({ appId });
+        if (configurations.length === 0) {
+          consola.warn('No native configurations found for this app.');
+        } else {
+          // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+          configuration = await prompt('Select the native configuration for the build:', {
+            type: 'select',
+            options: configurations.map((config) => ({ label: config.name, value: config.name })),
           });
         }
       }
@@ -381,6 +423,7 @@ export default defineCommand({
       adHocEnvironmentVariables,
       appBuildSourceId,
       appCertificateName: certificate,
+      appConfigurationName: configuration,
       appEnvironmentName: environment,
       appId,
       stack,

--- a/src/commands/apps/configurations/create.test.ts
+++ b/src/commands/apps/configurations/create.test.ts
@@ -1,0 +1,152 @@
+import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
+import authorizationService from '@/services/authorization-service.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import createConfigurationCommand from './create.js';
+
+// Mock dependencies
+vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/prompt.js');
+vi.mock('@/services/authorization-service.js');
+vi.mock('consola');
+vi.mock('@/utils/environment.js', () => ({
+  isInteractive: () => true,
+}));
+
+describe('apps-configurations-create', () => {
+  const mockUserConfig = vi.mocked(userConfig);
+  const mockPrompt = vi.mocked(prompt);
+  const mockPromptOrganizationSelection = vi.mocked(promptOrganizationSelection);
+  const mockPromptAppSelection = vi.mocked(promptAppSelection);
+  const mockConsola = vi.mocked(consola);
+  const mockAuthorizationService = vi.mocked(authorizationService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUserConfig.read.mockReturnValue({ token: 'test-token' });
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('test-token');
+    mockAuthorizationService.hasAuthorizationToken.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  it('should create configuration with provided options', async () => {
+    const appId = 'app-123';
+    const configurationName = 'production';
+    const displayName = 'My App';
+    const packageName = 'io.capawesome.app';
+    const configurationId = 'configuration-456';
+    const testToken = 'test-token';
+
+    const options = { appId, displayName, name: configurationName, packageName };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/configurations`, {
+        displayName,
+        name: configurationName,
+        packageName,
+      })
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: configurationId, name: configurationName });
+
+    await createConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.info).toHaveBeenCalledWith(`Native configuration ID: ${configurationId}`);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration created successfully.');
+  });
+
+  it('should output JSON when json flag is set', async () => {
+    const appId = 'app-123';
+    const configurationName = 'production';
+    const configurationId = 'configuration-456';
+    const testToken = 'test-token';
+
+    const options = { appId, json: true, name: configurationName };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/configurations`, {
+        name: configurationName,
+      })
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: configurationId, name: configurationName });
+
+    await createConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ id: configurationId }, null, 2));
+    expect(mockConsola.info).not.toHaveBeenCalled();
+  });
+
+  it('should prompt for app when not provided', async () => {
+    const orgId = 'org-1';
+    const appId = 'app-1';
+    const configurationName = 'staging';
+    const configurationId = 'configuration-456';
+    const testToken = 'test-token';
+
+    const options = { name: configurationName };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post(`/v1/apps/${appId}/configurations`, {
+        name: configurationName,
+      })
+      .matchHeader('Authorization', `Bearer ${testToken}`)
+      .reply(201, { id: configurationId, name: configurationName });
+
+    mockPromptOrganizationSelection.mockResolvedValueOnce(orgId);
+    mockPromptAppSelection.mockResolvedValueOnce(appId);
+
+    await createConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockPromptOrganizationSelection).toHaveBeenCalledWith({ allowCreate: true });
+    expect(mockPromptAppSelection).toHaveBeenCalledWith(orgId, { allowCreate: true });
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration created successfully.');
+  });
+
+  it('should prompt for configuration name when not provided', async () => {
+    const options = { appId: 'app-123' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post('/v1/apps/app-123/configurations', {
+        name: 'development',
+      })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(201, { id: 'configuration-456', name: 'development' });
+
+    mockPrompt.mockResolvedValueOnce('development');
+
+    await createConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockPrompt).toHaveBeenCalledWith('Enter the name of the native configuration:', { type: 'text' });
+  });
+
+  it('should handle API error', async () => {
+    const options = { appId: 'app-123', name: 'production' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .post('/v1/apps/app-123/configurations')
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(400, { message: 'Configuration name already exists' });
+
+    await expect(createConfigurationCommand.action(options, undefined)).rejects.toThrow();
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/apps/configurations/create.ts
+++ b/src/commands/apps/configurations/create.ts
@@ -1,0 +1,53 @@
+import appConfigurationsService from '@/services/app-configurations.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Create a new native configuration.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      displayName: z.string().optional().describe('Display name of the app.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
+      name: z.string().optional().describe('Name of the native configuration.'),
+      packageName: z.string().optional().describe('Package name (bundle ID) of the app.'),
+    }),
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, displayName, json, name, packageName } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection({ allowCreate: true });
+      appId = await promptAppSelection(organizationId, { allowCreate: true });
+    }
+
+    if (!name) {
+      if (!isInteractive()) {
+        consola.error('You must provide the native configuration name when running in non-interactive environment.');
+        process.exit(1);
+      }
+      name = await prompt('Enter the name of the native configuration:', { type: 'text' });
+    }
+
+    const response = await appConfigurationsService.create({
+      appId,
+      displayName: displayName === '' ? null : displayName,
+      name,
+      packageName: packageName === '' ? null : packageName,
+    });
+    if (json) {
+      console.log(JSON.stringify({ id: response.id }, null, 2));
+    } else {
+      consola.info(`Native configuration ID: ${response.id}`);
+      consola.success('Native configuration created successfully.');
+    }
+  }),
+});

--- a/src/commands/apps/configurations/create.ts
+++ b/src/commands/apps/configurations/create.ts
@@ -14,7 +14,10 @@ export default defineCommand({
       displayName: z.string().optional().describe('Display name of the app.'),
       json: z.boolean().optional().describe('Output in JSON format.'),
       name: z.string().optional().describe('Name of the native configuration.'),
-      packageName: z.string().optional().describe('Package name (bundle ID) of the app.'),
+      packageName: z
+        .string()
+        .optional()
+        .describe('Package name of the app (application ID on Android, bundle ID on iOS).'),
     }),
   ),
   action: withAuth(async (options, args) => {

--- a/src/commands/apps/configurations/delete.test.ts
+++ b/src/commands/apps/configurations/delete.test.ts
@@ -1,0 +1,144 @@
+import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
+import authorizationService from '@/services/authorization-service.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import deleteConfigurationCommand from './delete.js';
+
+// Mock dependencies
+vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/prompt.js');
+vi.mock('@/services/authorization-service.js');
+vi.mock('consola');
+vi.mock('@/utils/environment.js', () => ({
+  isInteractive: () => true,
+}));
+
+describe('apps-configurations-delete', () => {
+  const mockUserConfig = vi.mocked(userConfig);
+  const mockPrompt = vi.mocked(prompt);
+  const mockPromptOrganizationSelection = vi.mocked(promptOrganizationSelection);
+  const mockPromptAppSelection = vi.mocked(promptAppSelection);
+  const mockConsola = vi.mocked(consola);
+  const mockAuthorizationService = vi.mocked(authorizationService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUserConfig.read.mockReturnValue({ token: 'test-token' });
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('test-token');
+    mockAuthorizationService.hasAuthorizationToken.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  it('should delete configuration by ID after confirmation', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+
+    const options = { appId, configurationId };
+
+    mockPrompt.mockResolvedValueOnce(true); // confirmation
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .delete(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200);
+
+    await deleteConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockPrompt).toHaveBeenCalledWith('Are you sure you want to delete this native configuration?', {
+      type: 'confirm',
+    });
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration deleted successfully.');
+  });
+
+  it('should delete configuration by name when yes flag is set', async () => {
+    const appId = 'app-123';
+    const configurationName = 'production';
+
+    const options = { appId, name: configurationName, yes: true };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .delete(`/v1/apps/${appId}/configurations`)
+      .query({ name: configurationName })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200);
+
+    await deleteConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockPrompt).not.toHaveBeenCalled();
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration deleted successfully.');
+  });
+
+  it('should not delete configuration when confirmation is declined', async () => {
+    const options = { appId: 'app-123', configurationId: 'configuration-456' };
+
+    mockPrompt.mockResolvedValueOnce(false); // declined confirmation
+
+    await deleteConfigurationCommand.action(options, undefined);
+
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+
+  it('should prompt for app and configuration when not provided', async () => {
+    const orgId = 'org-1';
+    const appId = 'app-1';
+    const configurationId = 'configuration-456';
+    const configurationName = 'development';
+
+    const options = {};
+
+    const listScope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, [{ id: configurationId, appId, name: configurationName }]);
+    const deleteScope = nock(DEFAULT_API_BASE_URL)
+      .delete(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200);
+
+    mockPromptOrganizationSelection.mockResolvedValueOnce(orgId);
+    mockPromptAppSelection.mockResolvedValueOnce(appId);
+    mockPrompt
+      .mockResolvedValueOnce(configurationId) // configuration selection
+      .mockResolvedValueOnce(true); // confirmation
+
+    await deleteConfigurationCommand.action(options, undefined);
+
+    expect(listScope.isDone()).toBe(true);
+    expect(deleteScope.isDone()).toBe(true);
+    expect(mockPrompt).toHaveBeenCalledWith('Select the native configuration to delete:', {
+      type: 'select',
+      options: [{ label: configurationName, value: configurationId }],
+    });
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration deleted successfully.');
+  });
+
+  it('should handle API error', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+
+    const options = { appId, configurationId, yes: true };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .delete(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(404, { message: 'Configuration not found' });
+
+    await expect(deleteConfigurationCommand.action(options, undefined)).rejects.toThrow();
+
+    expect(scope.isDone()).toBe(true);
+  });
+});

--- a/src/commands/apps/configurations/delete.ts
+++ b/src/commands/apps/configurations/delete.ts
@@ -1,0 +1,71 @@
+import appConfigurationsService from '@/services/app-configurations.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Delete a native configuration.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      configurationId: z
+        .string()
+        .optional()
+        .describe('ID of the native configuration. Either the ID or name must be provided.'),
+      name: z.string().optional().describe('Name of the native configuration. Either the ID or name must be provided.'),
+      yes: z.boolean().optional().describe('Skip confirmation prompt.'),
+    }),
+    { y: 'yes' },
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, configurationId, name } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    if (!configurationId && !name) {
+      if (!isInteractive()) {
+        consola.error(
+          'You must provide either the native configuration ID or name when running in non-interactive environment.',
+        );
+        process.exit(1);
+      }
+      const configurations = await appConfigurationsService.findAll({ appId });
+      if (!configurations.length) {
+        consola.error('No native configurations found for this app. Create one first.');
+        process.exit(1);
+      }
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      const selectedConfigurationId = await prompt('Select the native configuration to delete:', {
+        type: 'select',
+        options: configurations.map((configuration) => ({ label: configuration.name, value: configuration.id })),
+      });
+      configurationId = selectedConfigurationId;
+    }
+
+    if (!options.yes && isInteractive()) {
+      const confirmed = await prompt('Are you sure you want to delete this native configuration?', {
+        type: 'confirm',
+      });
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    await appConfigurationsService.delete({
+      appId,
+      id: configurationId,
+      name,
+    });
+    consola.success('Native configuration deleted successfully.');
+  }),
+});

--- a/src/commands/apps/configurations/get.test.ts
+++ b/src/commands/apps/configurations/get.test.ts
@@ -1,0 +1,151 @@
+import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
+import authorizationService from '@/services/authorization-service.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import getConfigurationCommand from './get.js';
+
+// Mock dependencies
+vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/prompt.js');
+vi.mock('@/services/authorization-service.js');
+vi.mock('consola');
+vi.mock('@/utils/environment.js', () => ({
+  isInteractive: () => true,
+}));
+
+describe('apps-configurations-get', () => {
+  const mockUserConfig = vi.mocked(userConfig);
+  const mockPrompt = vi.mocked(prompt);
+  const mockPromptOrganizationSelection = vi.mocked(promptOrganizationSelection);
+  const mockPromptAppSelection = vi.mocked(promptAppSelection);
+  const mockConsola = vi.mocked(consola);
+  const mockAuthorizationService = vi.mocked(authorizationService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUserConfig.read.mockReturnValue({ token: 'test-token' });
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('test-token');
+    mockAuthorizationService.hasAuthorizationToken.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'table').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  it('should get configuration by ID and display table format', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+    const configuration = { id: configurationId, appId, name: 'production' };
+
+    const options = { appId, configurationId };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configuration);
+
+    await getConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(console.table).toHaveBeenCalledWith(configuration);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration retrieved successfully.');
+  });
+
+  it('should get configuration by name and display JSON format', async () => {
+    const appId = 'app-123';
+    const configurationName = 'staging';
+    const configuration = { id: 'configuration-789', appId, name: configurationName };
+
+    const options = { appId, json: true, name: configurationName };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .query({ name: configurationName })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, [configuration]);
+
+    await getConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(configuration, null, 2));
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+
+  it('should prompt for app and configuration when not provided', async () => {
+    const orgId = 'org-1';
+    const appId = 'app-1';
+    const configurationId = 'configuration-456';
+    const configurationName = 'development';
+    const configuration = { id: configurationId, appId, name: configurationName };
+
+    const options = {};
+
+    const listScope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, [configuration]);
+    const getScope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configuration);
+
+    mockPromptOrganizationSelection.mockResolvedValueOnce(orgId);
+    mockPromptAppSelection.mockResolvedValueOnce(appId);
+    mockPrompt.mockResolvedValueOnce(configurationId);
+
+    await getConfigurationCommand.action(options, undefined);
+
+    expect(listScope.isDone()).toBe(true);
+    expect(getScope.isDone()).toBe(true);
+    expect(mockPrompt).toHaveBeenCalledWith('Select the native configuration:', {
+      type: 'select',
+      options: [{ label: configurationName, value: configurationId }],
+    });
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration retrieved successfully.');
+  });
+
+  it('should handle configuration not found by name', async () => {
+    const appId = 'app-123';
+    const configurationName = 'nonexistent';
+
+    const options = { appId, name: configurationName };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .query({ name: configurationName })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, []);
+
+    await expect(getConfigurationCommand.action(options, undefined)).rejects.toThrow('Process exited with code 1');
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.error).toHaveBeenCalledWith('Native configuration not found.');
+  });
+
+  it('should handle API error', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+
+    const options = { appId, configurationId };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(500, { message: 'Internal server error' });
+
+    await expect(getConfigurationCommand.action(options, undefined)).rejects.toThrow();
+
+    expect(scope.isDone()).toBe(true);
+  });
+});

--- a/src/commands/apps/configurations/get.ts
+++ b/src/commands/apps/configurations/get.ts
@@ -1,0 +1,73 @@
+import appConfigurationsService from '@/services/app-configurations.js';
+import { AppConfigurationDto } from '@/types/app-configuration.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Get an existing native configuration.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      configurationId: z
+        .string()
+        .optional()
+        .describe('ID of the native configuration. Either the ID or name must be provided.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
+      name: z.string().optional().describe('Name of the native configuration. Either the ID or name must be provided.'),
+    }),
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, configurationId, json, name } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    if (!configurationId && !name) {
+      if (!isInteractive()) {
+        consola.error(
+          'You must provide either the native configuration ID or name when running in non-interactive environment.',
+        );
+        process.exit(1);
+      }
+      const configurations = await appConfigurationsService.findAll({ appId });
+      if (!configurations.length) {
+        consola.error('No native configurations found for this app. Create one first.');
+        process.exit(1);
+      }
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      configurationId = await prompt('Select the native configuration:', {
+        type: 'select',
+        options: configurations.map((configuration) => ({ label: configuration.name, value: configuration.id })),
+      });
+    }
+
+    let configuration: AppConfigurationDto | undefined;
+    if (configurationId) {
+      configuration = await appConfigurationsService.findOneById({ appId, id: configurationId });
+    } else if (name) {
+      const configurations = await appConfigurationsService.findAll({ appId, name });
+      configuration = configurations[0];
+    }
+    if (!configuration) {
+      consola.error('Native configuration not found.');
+      process.exit(1);
+    }
+
+    if (json) {
+      console.log(JSON.stringify(configuration, null, 2));
+    } else {
+      console.table(configuration);
+      consola.success('Native configuration retrieved successfully.');
+    }
+  }),
+});

--- a/src/commands/apps/configurations/list.test.ts
+++ b/src/commands/apps/configurations/list.test.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
+import authorizationService from '@/services/authorization-service.js';
+import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import listConfigurationsCommand from './list.js';
+
+// Mock dependencies
+vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/prompt.js');
+vi.mock('@/services/authorization-service.js');
+vi.mock('consola');
+vi.mock('@/utils/environment.js', () => ({
+  isInteractive: () => true,
+}));
+
+describe('apps-configurations-list', () => {
+  const mockUserConfig = vi.mocked(userConfig);
+  const mockPromptOrganizationSelection = vi.mocked(promptOrganizationSelection);
+  const mockPromptAppSelection = vi.mocked(promptAppSelection);
+  const mockConsola = vi.mocked(consola);
+  const mockAuthorizationService = vi.mocked(authorizationService);
+
+  const configurations = [{ id: 'configuration-456', appId: 'app-123', name: 'production' }];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUserConfig.read.mockReturnValue({ token: 'test-token' });
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('test-token');
+    mockAuthorizationService.hasAuthorizationToken.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'table').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  it('should list configurations and display table format', async () => {
+    const options = { appId: 'app-123' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/apps/app-123/configurations')
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configurations);
+
+    await listConfigurationsCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(console.table).toHaveBeenCalledWith(configurations);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configurations retrieved successfully.');
+  });
+
+  it('should output JSON when json flag is set', async () => {
+    const options = { appId: 'app-123', json: true };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/apps/app-123/configurations')
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configurations);
+
+    await listConfigurationsCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(configurations, null, 2));
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+
+  it('should forward pagination options', async () => {
+    const options = { appId: 'app-123', limit: 10, offset: 20 };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/apps/app-123/configurations')
+      .query({ limit: '10', offset: '20' })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configurations);
+
+    await listConfigurationsCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should prompt for app when not provided', async () => {
+    const orgId = 'org-1';
+    const appId = 'app-1';
+
+    const options = {};
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configurations);
+
+    mockPromptOrganizationSelection.mockResolvedValueOnce(orgId);
+    mockPromptAppSelection.mockResolvedValueOnce(appId);
+
+    await listConfigurationsCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configurations retrieved successfully.');
+  });
+
+  it('should handle API error', async () => {
+    const options = { appId: 'app-123' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .get('/v1/apps/app-123/configurations')
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(500, { message: 'Internal server error' });
+
+    await expect(listConfigurationsCommand.action(options, undefined)).rejects.toThrow();
+
+    expect(scope.isDone()).toBe(true);
+  });
+});

--- a/src/commands/apps/configurations/list.ts
+++ b/src/commands/apps/configurations/list.ts
@@ -1,0 +1,44 @@
+import appConfigurationsService from '@/services/app-configurations.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'List all native configurations for an app.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
+      limit: z.coerce.number().optional().describe('Limit for pagination.'),
+      offset: z.coerce.number().optional().describe('Offset for pagination.'),
+    }),
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, json, limit, offset } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    const configurations = await appConfigurationsService.findAll({
+      appId,
+      limit,
+      offset,
+    });
+
+    if (json) {
+      console.log(JSON.stringify(configurations, null, 2));
+    } else {
+      console.table(configurations);
+      consola.success('Native configurations retrieved successfully.');
+    }
+  }),
+});

--- a/src/commands/apps/configurations/update.test.ts
+++ b/src/commands/apps/configurations/update.test.ts
@@ -1,0 +1,154 @@
+import { DEFAULT_API_BASE_URL } from '@/config/consts.js';
+import authorizationService from '@/services/authorization-service.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import userConfig from '@/utils/user-config.js';
+import consola from 'consola';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import updateConfigurationCommand from './update.js';
+
+// Mock dependencies
+vi.mock('@/utils/user-config.js');
+vi.mock('@/utils/prompt.js');
+vi.mock('@/services/authorization-service.js');
+vi.mock('consola');
+vi.mock('@/utils/environment.js', () => ({
+  isInteractive: () => true,
+}));
+
+describe('apps-configurations-update', () => {
+  const mockUserConfig = vi.mocked(userConfig);
+  const mockPrompt = vi.mocked(prompt);
+  const mockPromptOrganizationSelection = vi.mocked(promptOrganizationSelection);
+  const mockPromptAppSelection = vi.mocked(promptAppSelection);
+  const mockConsola = vi.mocked(consola);
+  const mockAuthorizationService = vi.mocked(authorizationService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUserConfig.read.mockReturnValue({ token: 'test-token' });
+    mockAuthorizationService.getCurrentAuthorizationToken.mockReturnValue('test-token');
+    mockAuthorizationService.hasAuthorizationToken.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    vi.restoreAllMocks();
+  });
+
+  it('should update configuration with provided options', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+    const displayName = 'My App';
+    const packageName = 'io.capawesome.app';
+
+    const options = { appId, configurationId, displayName, packageName };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/configurations/${configurationId}`, {
+        displayName,
+        packageName,
+      })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, { id: configurationId, appId, displayName, packageName });
+
+    await updateConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration updated successfully.');
+  });
+
+  it('should clear display name and package name when empty strings are provided', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+
+    const options = { appId, configurationId, displayName: '', packageName: '' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/configurations/${configurationId}`, {
+        displayName: null,
+        packageName: null,
+      })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, { id: configurationId, appId, displayName: null, packageName: null });
+
+    await updateConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration updated successfully.');
+  });
+
+  it('should output JSON when json flag is set', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+    const configuration = { id: configurationId, appId, name: 'production' };
+
+    const options = { appId, configurationId, json: true, name: 'production' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/configurations/${configurationId}`, { name: 'production' })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, configuration);
+
+    await updateConfigurationCommand.action(options, undefined);
+
+    expect(scope.isDone()).toBe(true);
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(configuration, null, 2));
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+
+  it('should prompt for app and configuration when not provided', async () => {
+    const orgId = 'org-1';
+    const appId = 'app-1';
+    const configurationId = 'configuration-456';
+    const configurationName = 'development';
+
+    const options = { displayName: 'My App' };
+
+    const listScope = nock(DEFAULT_API_BASE_URL)
+      .get(`/v1/apps/${appId}/configurations`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, [{ id: configurationId, appId, name: configurationName }]);
+    const updateScope = nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/configurations/${configurationId}`, { displayName: 'My App' })
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(200, { id: configurationId, appId, name: configurationName });
+
+    mockPromptOrganizationSelection.mockResolvedValueOnce(orgId);
+    mockPromptAppSelection.mockResolvedValueOnce(appId);
+    mockPrompt.mockResolvedValueOnce(configurationId);
+
+    await updateConfigurationCommand.action(options, undefined);
+
+    expect(listScope.isDone()).toBe(true);
+    expect(updateScope.isDone()).toBe(true);
+    expect(mockPrompt).toHaveBeenCalledWith('Select the native configuration to update:', {
+      type: 'select',
+      options: [{ label: configurationName, value: configurationId }],
+    });
+    expect(mockConsola.success).toHaveBeenCalledWith('Native configuration updated successfully.');
+  });
+
+  it('should handle API error', async () => {
+    const appId = 'app-123';
+    const configurationId = 'configuration-456';
+
+    const options = { appId, configurationId, name: 'production' };
+
+    const scope = nock(DEFAULT_API_BASE_URL)
+      .patch(`/v1/apps/${appId}/configurations/${configurationId}`)
+      .matchHeader('Authorization', 'Bearer test-token')
+      .reply(404, { message: 'Configuration not found' });
+
+    await expect(updateConfigurationCommand.action(options, undefined)).rejects.toThrow();
+
+    expect(scope.isDone()).toBe(true);
+    expect(mockConsola.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/apps/configurations/update.ts
+++ b/src/commands/apps/configurations/update.ts
@@ -18,7 +18,9 @@ export default defineCommand({
       packageName: z
         .string()
         .optional()
-        .describe('Package name (bundle ID) of the app. Pass an empty string to clear it.'),
+        .describe(
+          'Package name of the app (application ID on Android, bundle ID on iOS). Pass an empty string to clear it.',
+        ),
     }),
   ),
   action: withAuth(async (options, args) => {

--- a/src/commands/apps/configurations/update.ts
+++ b/src/commands/apps/configurations/update.ts
@@ -1,0 +1,66 @@
+import appConfigurationsService from '@/services/app-configurations.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import { z } from 'zod';
+
+export default defineCommand({
+  description: 'Update an existing native configuration.',
+  options: defineOptions(
+    z.object({
+      appId: z.string().optional().describe('ID of the app.'),
+      configurationId: z.string().optional().describe('ID of the native configuration.'),
+      displayName: z.string().optional().describe('Display name of the app. Pass an empty string to clear it.'),
+      json: z.boolean().optional().describe('Output in JSON format.'),
+      name: z.string().optional().describe('Name of the native configuration.'),
+      packageName: z
+        .string()
+        .optional()
+        .describe('Package name (bundle ID) of the app. Pass an empty string to clear it.'),
+    }),
+  ),
+  action: withAuth(async (options, args) => {
+    let { appId, configurationId, displayName, json, name, packageName } = options;
+
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    if (!configurationId) {
+      if (!isInteractive()) {
+        consola.error('You must provide the native configuration ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const configurations = await appConfigurationsService.findAll({ appId });
+      if (!configurations.length) {
+        consola.error('No native configurations found for this app. Create one first.');
+        process.exit(1);
+      }
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      configurationId = await prompt('Select the native configuration to update:', {
+        type: 'select',
+        options: configurations.map((configuration) => ({ label: configuration.name, value: configuration.id })),
+      });
+    }
+
+    const configuration = await appConfigurationsService.update({
+      appId,
+      configurationId,
+      displayName: displayName === '' ? null : displayName,
+      name,
+      packageName: packageName === '' ? null : packageName,
+    });
+    if (json) {
+      console.log(JSON.stringify(configuration, null, 2));
+    } else {
+      consola.success('Native configuration updated successfully.');
+    }
+  }),
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,11 @@ const config = defineConfig({
     'apps:channels:pause': await import('@/commands/apps/channels/pause.js').then((mod) => mod.default),
     'apps:channels:resume': await import('@/commands/apps/channels/resume.js').then((mod) => mod.default),
     'apps:channels:update': await import('@/commands/apps/channels/update.js').then((mod) => mod.default),
+    'apps:configurations:create': await import('@/commands/apps/configurations/create.js').then((mod) => mod.default),
+    'apps:configurations:delete': await import('@/commands/apps/configurations/delete.js').then((mod) => mod.default),
+    'apps:configurations:get': await import('@/commands/apps/configurations/get.js').then((mod) => mod.default),
+    'apps:configurations:list': await import('@/commands/apps/configurations/list.js').then((mod) => mod.default),
+    'apps:configurations:update': await import('@/commands/apps/configurations/update.js').then((mod) => mod.default),
     'apps:deployments:create': await import('@/commands/apps/deployments/create.js').then((mod) => mod.default),
     'apps:deployments:cancel': await import('@/commands/apps/deployments/cancel.js').then((mod) => mod.default),
     'apps:deployments:failure-summary': await import('@/commands/apps/deployments/failure-summary.js').then(

--- a/src/services/app-configurations.ts
+++ b/src/services/app-configurations.ts
@@ -1,0 +1,105 @@
+import authorizationService from '@/services/authorization-service.js';
+import {
+  AppConfigurationDto,
+  CreateAppConfigurationDto,
+  DeleteAppConfigurationDto,
+  FindAllAppConfigurationsDto,
+  FindOneAppConfigurationByIdDto,
+  UpdateAppConfigurationDto,
+} from '@/types/app-configuration.js';
+import httpClient, { HttpClient } from '@/utils/http-client.js';
+
+export interface AppConfigurationsService {
+  create(dto: CreateAppConfigurationDto): Promise<AppConfigurationDto>;
+  delete(dto: DeleteAppConfigurationDto): Promise<void>;
+  findAll(dto: FindAllAppConfigurationsDto): Promise<AppConfigurationDto[]>;
+  findOneById(dto: FindOneAppConfigurationByIdDto): Promise<AppConfigurationDto>;
+  update(dto: UpdateAppConfigurationDto): Promise<AppConfigurationDto>;
+}
+
+class AppConfigurationsServiceImpl implements AppConfigurationsService {
+  private readonly httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+  }
+
+  async create(dto: CreateAppConfigurationDto): Promise<AppConfigurationDto> {
+    const { appId, ...bodyData } = dto;
+    const response = await this.httpClient.post<AppConfigurationDto>(`/v1/apps/${appId}/configurations`, bodyData, {
+      headers: {
+        Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+      },
+    });
+    return response.data;
+  }
+
+  async delete(dto: DeleteAppConfigurationDto): Promise<void> {
+    if (dto.id) {
+      await this.httpClient.delete(`/v1/apps/${dto.appId}/configurations/${dto.id}`, {
+        headers: {
+          Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+        },
+      });
+    } else if (dto.name) {
+      await this.httpClient.delete(`/v1/apps/${dto.appId}/configurations`, {
+        headers: {
+          Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+        },
+        params: {
+          name: dto.name,
+        },
+      });
+    }
+  }
+
+  async findAll(dto: FindAllAppConfigurationsDto): Promise<AppConfigurationDto[]> {
+    const params: Record<string, string> = {};
+    if (dto.limit !== undefined) {
+      params.limit = dto.limit.toString();
+    }
+    if (dto.name) {
+      params.name = dto.name;
+    }
+    if (dto.offset !== undefined) {
+      params.offset = dto.offset.toString();
+    }
+    if (dto.query) {
+      params.query = dto.query;
+    }
+    const response = await this.httpClient.get<AppConfigurationDto[]>(`/v1/apps/${dto.appId}/configurations`, {
+      headers: {
+        Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+      },
+      params,
+    });
+    return response.data;
+  }
+
+  async findOneById(dto: FindOneAppConfigurationByIdDto): Promise<AppConfigurationDto> {
+    const response = await this.httpClient.get<AppConfigurationDto>(`/v1/apps/${dto.appId}/configurations/${dto.id}`, {
+      headers: {
+        Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+      },
+    });
+    return response.data;
+  }
+
+  async update(dto: UpdateAppConfigurationDto): Promise<AppConfigurationDto> {
+    const { appId, configurationId, ...bodyData } = dto;
+    const response = await this.httpClient.patch<AppConfigurationDto>(
+      `/v1/apps/${appId}/configurations/${configurationId}`,
+      bodyData,
+      {
+        headers: {
+          Authorization: `Bearer ${authorizationService.getCurrentAuthorizationToken()}`,
+        },
+      },
+    );
+    return response.data;
+  }
+}
+
+const appConfigurationsService = new AppConfigurationsServiceImpl(httpClient);
+
+export default appConfigurationsService;

--- a/src/types/app-build.ts
+++ b/src/types/app-build.ts
@@ -14,6 +14,7 @@ export interface AppBuildDto {
   appBuildArtifactId: string | null;
   appBuildArtifacts?: AppBuildArtifactDto[];
   appCertificateId?: string;
+  appConfigurationId?: string;
   appEnvironmentId?: string;
   appBuildSourceId?: string;
   appId: string;
@@ -29,6 +30,7 @@ export interface CreateAppBuildDto {
   adHocEnvironmentVariables?: Record<string, string>;
   appBuildSourceId?: string;
   appCertificateName?: string;
+  appConfigurationName?: string;
   appEnvironmentName?: string;
   appId: string;
   stack?: 'macos-sequoia' | 'macos-tahoe';

--- a/src/types/app-configuration.ts
+++ b/src/types/app-configuration.ts
@@ -1,0 +1,45 @@
+export interface AppConfigurationDto {
+  id: string;
+  appId: string;
+  name: string;
+  displayName: string | null;
+  packageName: string | null;
+  createdAt: string;
+  createdBy: string;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+export interface CreateAppConfigurationDto {
+  appId: string;
+  name: string;
+  displayName?: string | null;
+  packageName?: string | null;
+}
+
+export interface UpdateAppConfigurationDto {
+  appId: string;
+  configurationId: string;
+  name?: string;
+  displayName?: string | null;
+  packageName?: string | null;
+}
+
+export interface DeleteAppConfigurationDto {
+  appId: string;
+  id?: string;
+  name?: string;
+}
+
+export interface FindAllAppConfigurationsDto {
+  appId: string;
+  limit?: number;
+  name?: string;
+  offset?: number;
+  query?: string;
+}
+
+export interface FindOneAppConfigurationByIdDto {
+  appId: string;
+  id: string;
+}


### PR DESCRIPTION
## Description

Adds commands to manage **native configurations** — named, per-app records in Capawesome Cloud that override an app's display name and package name (bundle ID) in the native project at build time.

This is the CLI half of a five-repo feature.

## Changes

**New commands**

- `apps:configurations:create` — `--app-id`, `--display-name`, `--json`, `--name`, `--package-name`
- `apps:configurations:list` — `--app-id`, `--json`, `--limit`, `--offset`
- `apps:configurations:get` — `--app-id`, `--configuration-id`, `--json`, `--name`
- `apps:configurations:update` — `--app-id`, `--configuration-id`, `--display-name`, `--json`, `--name`, `--package-name`
- `apps:configurations:delete` — `--app-id`, `--configuration-id`, `--name`, `--yes`/`-y`

Passing an empty string to `--display-name` or `--package-name` clears the value.

**Build integration**

- `apps:builds:create` gains `--configuration <name>`, plus an optional interactive picker matching the existing `--environment` flow
- `CreateAppBuildDto` gains `appConfigurationName`; `AppBuildDto` gains `appConfigurationId`

Native configurations apply to Android and iOS only. The platform check is an explicit allow-list rather than a `!== 'web'` exclusion, so platforms added later are not accidentally permitted.

## Naming

Command names use the shorter `configurations` spelling to match the API resource, which is deliberately platform-neutral so web configurations can be added later. User-facing output says "native configuration", since the feature is Android/iOS-only today.

## Testing

`npm run build`, `npm test` (229 passing) and `npm run lint` all pass. New coverage for all five commands plus the build-flag platform guard.

## Related pull requests

- API: https://github.com/capawesome-team/cloud-api-worker/pull/743
