### PR TITLE
feat(apps): add `apps:builds:run` command

### DIFF
--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -57,7 +57,6 @@ export default defineCommand({
         .optional()
         .describe('Build ID to run.'),
       buildNumber: z.string().optional().describe('Build number to run (e.g., "1", "42").'),
-      list: z.boolean().optional().describe('Print a list of the emulators and simulators available on this machine.'),
       target: z.string().optional().describe('Run on a specific target device by its ID.'),
       targetName: z
         .string()
@@ -73,13 +72,7 @@ export default defineCommand({
   ),
   action: withAuth(async (options) => {
     let { appId, buildId } = options;
-    const { buildNumber, list, target, targetName, targetNameSdkVersion } = options;
-
-    // Listing the local emulators and simulators does not require a build.
-    if (list) {
-      handleTargetList();
-      return;
-    }
+    const { buildNumber, target, targetName, targetNameSdkVersion } = options;
 
     if (targetNameSdkVersion && !targetName) {
       consola.error('You must provide --target-name when using --target-name-sdk-version.');
@@ -180,49 +173,6 @@ export default defineCommand({
     }
   }),
 });
-
-/**
- * Print every emulator and simulator available on this machine.
- */
-const handleTargetList = (): void => {
-  const rows: { id: string; name: string; platform: string; running: boolean; sdkVersion: string | null }[] = [];
-  try {
-    rows.push(
-      ...findAllAndroidEmulators().map(({ id, name, running, sdkVersion }) => ({
-        id,
-        name,
-        platform: 'android',
-        running,
-        sdkVersion,
-      })),
-    );
-  } catch {
-    // Ignore machines without an Android SDK.
-  }
-  if (process.platform === 'darwin') {
-    try {
-      rows.push(
-        ...findAllIosSimulators().map(({ id, name, running, sdkVersion }) => ({
-          id,
-          name,
-          platform: 'ios',
-          running,
-          sdkVersion,
-        })),
-      );
-    } catch {
-      // Ignore machines without Xcode.
-    }
-  }
-
-  if (rows.length === 0) {
-    consola.error(
-      'No emulators or simulators found. Create an Android emulator in Android Studio or install an iOS simulator via Xcode.',
-    );
-    process.exit(1);
-  }
-  console.table(rows);
-};
 
 /**
  * Ensure the build can be run locally and return its package name.

--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -1,6 +1,7 @@
 import appBuildsService from '@/services/app-builds.js';
 import { AppBuildDto } from '@/types/app-build.js';
 import {
+  AndroidEmulator,
   bootAndroidEmulator,
   findAllAndroidEmulators,
   installAndroidApp,
@@ -8,7 +9,13 @@ import {
 } from '@/utils/android-emulator.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { bootIosSimulator, findAllIosSimulators, installIosApp, launchIosApp } from '@/utils/ios-simulator.js';
+import {
+  bootIosSimulator,
+  findAllIosSimulators,
+  installIosApp,
+  IosSimulator,
+  launchIosApp,
+} from '@/utils/ios-simulator.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
 import { defineCommand, defineOptions } from '@robingenz/zli';
@@ -18,11 +25,19 @@ import os from 'os';
 import path from 'path';
 import { z } from 'zod';
 
-interface DeviceOption<T> {
+interface Target<T> {
   device: T;
+  id: string;
   label: string;
   name: string;
   running: boolean;
+  sdkVersion: string | null;
+}
+
+interface TargetSelection {
+  target?: string;
+  targetName?: string;
+  targetNameSdkVersion?: string;
 }
 
 export default defineCommand({
@@ -42,12 +57,28 @@ export default defineCommand({
         .optional()
         .describe('Build ID to run.'),
       buildNumber: z.string().optional().describe('Build number to run (e.g., "1", "42").'),
-      device: z.string().optional().describe('Name of the emulator or simulator to run the build on.'),
+      list: z.boolean().optional().describe('Print a list of target devices available for the build.'),
+      target: z.string().optional().describe('Run on a specific target device by its ID.'),
+      targetName: z
+        .string()
+        .optional()
+        .describe('Run on a specific target device by its name (e.g. "Pixel 8 Pro", "iPhone 17 Pro").'),
+      targetNameSdkVersion: z
+        .string()
+        .optional()
+        .describe(
+          'Run on a target device by name with a specific SDK version when using --target-name (e.g. "18.2" for iOS 18.2 or "35" for Android API 35).',
+        ),
     }),
   ),
   action: withAuth(async (options) => {
     let { appId, buildId } = options;
-    const { buildNumber, device } = options;
+    const { buildNumber, list, target, targetName, targetNameSdkVersion } = options;
+
+    if (targetNameSdkVersion && !targetName) {
+      consola.error('You must provide --target-name when using --target-name-sdk-version.');
+      process.exit(1);
+    }
 
     // Prompt for app ID if not provided
     if (!appId) {
@@ -97,7 +128,32 @@ export default defineCommand({
     const build = await appBuildsService.findOne({ appId, appBuildId: buildId, relations: 'appBuildArtifacts,job' });
     const packageName = validateAppBuild(build);
 
-    const artifactType = build.platform === 'android' ? 'apk' : 'app';
+    const isAndroid = build.platform === 'android';
+    const androidTargets = isAndroid ? findAllAndroidEmulators().map(toAndroidTarget) : [];
+    const iosTargets = isAndroid ? [] : findAllIosSimulators().map(toIosTarget);
+    const targets = isAndroid ? androidTargets : iosTargets;
+    if (targets.length === 0) {
+      consola.error(
+        isAndroid
+          ? 'No Android emulators found. Create one in Android Studio and try again.'
+          : 'No iOS simulators found. Install one via Xcode and try again.',
+      );
+      process.exit(1);
+    }
+
+    if (list) {
+      console.table(
+        targets.map(({ id, name, running, sdkVersion }) => ({
+          id,
+          name,
+          sdkVersion,
+          running,
+        })),
+      );
+      return;
+    }
+
+    const artifactType = isAndroid ? 'apk' : 'app';
     const artifact = build.appBuildArtifacts?.find(
       (artifact) => artifact.type === artifactType && artifact.status === 'ready',
     );
@@ -115,13 +171,18 @@ export default defineCommand({
     const temporaryDirectoryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'capawesome-'));
     consola.success('Build downloaded.');
 
-    if (build.platform === 'android') {
-      const apkPath = path.join(temporaryDirectoryPath, 'app.apk');
-      await fs.writeFile(apkPath, Buffer.from(artifactData));
-      await handleAndroidRun({ apkPath, deviceName: device, packageName });
-    } else {
-      const appPath = await extractAppBundle(Buffer.from(artifactData), temporaryDirectoryPath);
-      await handleIosRun({ appPath, deviceName: device, packageName });
+    const targetSelection: TargetSelection = { target, targetName, targetNameSdkVersion };
+    try {
+      if (isAndroid) {
+        const apkPath = path.join(temporaryDirectoryPath, 'app.apk');
+        await fs.writeFile(apkPath, Buffer.from(artifactData));
+        await handleAndroidRun({ apkPath, packageName, targets: androidTargets, targetSelection });
+      } else {
+        const appPath = await extractAppBundle(Buffer.from(artifactData), temporaryDirectoryPath);
+        await handleIosRun({ appPath, packageName, targets: iosTargets, targetSelection });
+      }
+    } finally {
+      await fs.rm(temporaryDirectoryPath, { force: true, recursive: true });
     }
   }),
 });
@@ -171,43 +232,80 @@ const extractAppBundle = async (artifactData: Buffer, targetFolder: string): Pro
   return path.join(targetFolder, appBundleName);
 };
 
+const toAndroidTarget = (emulator: AndroidEmulator): Target<AndroidEmulator> => ({
+  device: emulator,
+  id: emulator.id,
+  label: emulator.sdkVersion ? `${emulator.name} (API ${emulator.sdkVersion})` : emulator.name,
+  name: emulator.name,
+  running: emulator.running,
+  sdkVersion: emulator.sdkVersion,
+});
+
+const toIosTarget = (simulator: IosSimulator): Target<IosSimulator> => ({
+  device: simulator,
+  id: simulator.id,
+  label: `${simulator.name} (iOS ${simulator.sdkVersion})`,
+  name: simulator.name,
+  running: simulator.running,
+  sdkVersion: simulator.sdkVersion,
+});
+
 /**
- * Select the device to run the build on, preferring devices that are already running.
+ * Select the target device to run the build on, preferring targets that are already running.
  */
-const selectDevice = async <T>(deviceOptions: DeviceOption<T>[], deviceName?: string): Promise<T> => {
-  const sortedDeviceOptions = [...deviceOptions].sort(
-    (deviceOption, otherDeviceOption) => Number(otherDeviceOption.running) - Number(deviceOption.running),
+const selectTarget = async <T>(targets: Target<T>[], selection: TargetSelection): Promise<T> => {
+  const sortedTargets = [...targets].sort(
+    (target, otherTarget) => Number(otherTarget.running) - Number(target.running),
   );
 
-  if (deviceName) {
-    const matchingDeviceOption = sortedDeviceOptions.find((deviceOption) => deviceOption.name === deviceName);
-    if (!matchingDeviceOption) {
-      consola.error(`The device "${deviceName}" was not found.`);
+  if (selection.target) {
+    const matchingTarget = sortedTargets.find((target) => target.id === selection.target);
+    if (!matchingTarget) {
+      consola.error(`No target device with the ID "${selection.target}" was found.`);
       process.exit(1);
     }
-    return matchingDeviceOption.device;
+    return matchingTarget.device;
+  }
+
+  if (selection.targetName) {
+    const matchingTargets = sortedTargets.filter(
+      (target) =>
+        target.name === selection.targetName &&
+        (!selection.targetNameSdkVersion || target.sdkVersion === selection.targetNameSdkVersion),
+    );
+    const matchingTarget = matchingTargets[0];
+    if (!matchingTarget) {
+      consola.error(`No target device named "${selection.targetName}" was found.`);
+      process.exit(1);
+    }
+    if (matchingTargets.length > 1) {
+      consola.warn(
+        `Multiple target devices named "${selection.targetName}" were found. Using "${matchingTarget.label}". Use --target-name-sdk-version or --target to select a specific one.`,
+      );
+    }
+    return matchingTarget.device;
   }
 
   if (!isInteractive()) {
-    consola.error('You must provide a device when running in non-interactive environment.');
+    consola.error('You must provide a target device when running in non-interactive environment.');
     process.exit(1);
   }
 
   // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
-  const selectedIndex: string = await prompt('Select the device you want to run the build on:', {
+  const selectedIndex: string = await prompt('Select the target device you want to run the build on:', {
     type: 'select',
-    options: sortedDeviceOptions.map((deviceOption, index) => ({
-      label: deviceOption.running ? `${deviceOption.label} (running)` : deviceOption.label,
+    options: sortedTargets.map((target, index) => ({
+      label: target.running ? `${target.label} (running)` : target.label,
       value: `${index}`,
     })),
   });
 
-  const selectedDeviceOption = sortedDeviceOptions[Number(selectedIndex)];
-  if (!selectedDeviceOption) {
-    consola.error('You must select a device to run the build on.');
+  const selectedTarget = sortedTargets[Number(selectedIndex)];
+  if (!selectedTarget) {
+    consola.error('You must select a target device to run the build on.');
     process.exit(1);
   }
-  return selectedDeviceOption.device;
+  return selectedTarget.device;
 };
 
 /**
@@ -215,25 +313,13 @@ const selectDevice = async <T>(deviceOptions: DeviceOption<T>[], deviceName?: st
  */
 const handleAndroidRun = async (options: {
   apkPath: string;
-  deviceName?: string;
   packageName: string;
+  targets: Target<AndroidEmulator>[];
+  targetSelection: TargetSelection;
 }): Promise<void> => {
-  const { apkPath, deviceName, packageName } = options;
+  const { apkPath, packageName, targets, targetSelection } = options;
 
-  const emulators = findAllAndroidEmulators();
-  if (emulators.length === 0) {
-    consola.error('No Android emulators found. Create one in Android Studio and try again.');
-    process.exit(1);
-  }
-  const emulator = await selectDevice(
-    emulators.map((emulator) => ({
-      device: emulator,
-      label: emulator.name,
-      name: emulator.name,
-      running: emulator.running,
-    })),
-    deviceName,
-  );
+  const emulator = await selectTarget(targets, targetSelection);
 
   consola.start(emulator.running ? `Using emulator "${emulator.name}"...` : `Starting emulator "${emulator.name}"...`);
   const serial = await bootAndroidEmulator(emulator);
@@ -251,23 +337,15 @@ const handleAndroidRun = async (options: {
 /**
  * Run an iOS build on a local simulator.
  */
-const handleIosRun = async (options: { appPath: string; deviceName?: string; packageName: string }): Promise<void> => {
-  const { appPath, deviceName, packageName } = options;
+const handleIosRun = async (options: {
+  appPath: string;
+  packageName: string;
+  targets: Target<IosSimulator>[];
+  targetSelection: TargetSelection;
+}): Promise<void> => {
+  const { appPath, packageName, targets, targetSelection } = options;
 
-  const simulators = findAllIosSimulators();
-  if (simulators.length === 0) {
-    consola.error('No iOS simulators found. Install one via Xcode and try again.');
-    process.exit(1);
-  }
-  const simulator = await selectDevice(
-    simulators.map((simulator) => ({
-      device: simulator,
-      label: `${simulator.name} (${simulator.runtime})`,
-      name: simulator.name,
-      running: simulator.running,
-    })),
-    deviceName,
-  );
+  const simulator = await selectTarget(targets, targetSelection);
 
   consola.start(
     simulator.running ? `Using simulator "${simulator.name}"...` : `Starting simulator "${simulator.name}"...`,
@@ -276,10 +354,10 @@ const handleIosRun = async (options: { appPath: string; deviceName?: string; pac
   consola.success(`Simulator "${simulator.name}" is running.`);
 
   consola.start('Installing app...');
-  installIosApp(simulator.udid, appPath);
+  installIosApp(simulator.id, appPath);
   consola.success('App installed.');
 
   consola.start('Launching app...');
-  launchIosApp(simulator.udid, packageName);
+  launchIosApp(simulator.id, packageName);
   consola.success('App launched.');
 };

--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -67,7 +67,7 @@ export default defineCommand({
         .string()
         .optional()
         .describe(
-          'Run on a target device by name with a specific SDK version when using --target-name (e.g. "18.2" for iOS 18.2 or "35" for Android API 35).',
+          'Run on a target device by name with a specific SDK version when using --target-name (e.g. "26.5" for iOS 26.5 or "35" for Android API 35).',
         ),
     }),
   ),

--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -57,7 +57,7 @@ export default defineCommand({
         .optional()
         .describe('Build ID to run.'),
       buildNumber: z.string().optional().describe('Build number to run (e.g., "1", "42").'),
-      list: z.boolean().optional().describe('Print a list of target devices available for the build.'),
+      list: z.boolean().optional().describe('Print a list of the emulators and simulators available on this machine.'),
       target: z.string().optional().describe('Run on a specific target device by its ID.'),
       targetName: z
         .string()
@@ -74,6 +74,12 @@ export default defineCommand({
   action: withAuth(async (options) => {
     let { appId, buildId } = options;
     const { buildNumber, list, target, targetName, targetNameSdkVersion } = options;
+
+    // Listing the local emulators and simulators does not require a build.
+    if (list) {
+      handleTargetList();
+      return;
+    }
 
     if (targetNameSdkVersion && !targetName) {
       consola.error('You must provide --target-name when using --target-name-sdk-version.');
@@ -141,18 +147,6 @@ export default defineCommand({
       process.exit(1);
     }
 
-    if (list) {
-      console.table(
-        targets.map(({ id, name, running, sdkVersion }) => ({
-          id,
-          name,
-          sdkVersion,
-          running,
-        })),
-      );
-      return;
-    }
-
     const artifactType = isAndroid ? 'apk' : 'app';
     const artifact = build.appBuildArtifacts?.find(
       (artifact) => artifact.type === artifactType && artifact.status === 'ready',
@@ -186,6 +180,49 @@ export default defineCommand({
     }
   }),
 });
+
+/**
+ * Print every emulator and simulator available on this machine.
+ */
+const handleTargetList = (): void => {
+  const rows: { id: string; name: string; platform: string; running: boolean; sdkVersion: string | null }[] = [];
+  try {
+    rows.push(
+      ...findAllAndroidEmulators().map(({ id, name, running, sdkVersion }) => ({
+        id,
+        name,
+        platform: 'android',
+        running,
+        sdkVersion,
+      })),
+    );
+  } catch {
+    // Ignore machines without an Android SDK.
+  }
+  if (process.platform === 'darwin') {
+    try {
+      rows.push(
+        ...findAllIosSimulators().map(({ id, name, running, sdkVersion }) => ({
+          id,
+          name,
+          platform: 'ios',
+          running,
+          sdkVersion,
+        })),
+      );
+    } catch {
+      // Ignore machines without Xcode.
+    }
+  }
+
+  if (rows.length === 0) {
+    consola.error(
+      'No emulators or simulators found. Create an Android emulator in Android Studio or install an iOS simulator via Xcode.',
+    );
+    process.exit(1);
+  }
+  console.table(rows);
+};
 
 /**
  * Ensure the build can be run locally and return its package name.

--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -1,0 +1,285 @@
+import appBuildsService from '@/services/app-builds.js';
+import { AppBuildDto } from '@/types/app-build.js';
+import {
+  bootAndroidEmulator,
+  findAllAndroidEmulators,
+  installAndroidApp,
+  launchAndroidApp,
+} from '@/utils/android-emulator.js';
+import { withAuth } from '@/utils/auth.js';
+import { isInteractive } from '@/utils/environment.js';
+import { bootIosSimulator, findAllIosSimulators, installIosApp, launchIosApp } from '@/utils/ios-simulator.js';
+import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
+import zip from '@/utils/zip.js';
+import { defineCommand, defineOptions } from '@robingenz/zli';
+import consola from 'consola';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { z } from 'zod';
+
+interface DeviceOption<T> {
+  device: T;
+  label: string;
+  name: string;
+  running: boolean;
+}
+
+export default defineCommand({
+  description: 'Run an app build on a local emulator or simulator.',
+  options: defineOptions(
+    z.object({
+      appId: z
+        .uuid({
+          message: 'App ID must be a UUID.',
+        })
+        .optional()
+        .describe('App ID the build belongs to.'),
+      buildId: z
+        .uuid({
+          message: 'Build ID must be a UUID.',
+        })
+        .optional()
+        .describe('Build ID to run.'),
+      buildNumber: z.string().optional().describe('Build number to run (e.g., "1", "42").'),
+      device: z.string().optional().describe('Name of the emulator or simulator to run the build on.'),
+    }),
+  ),
+  action: withAuth(async (options) => {
+    let { appId, buildId } = options;
+    const { buildNumber, device } = options;
+
+    // Prompt for app ID if not provided
+    if (!appId) {
+      if (!isInteractive()) {
+        consola.error('You must provide an app ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const organizationId = await promptOrganizationSelection();
+      appId = await promptAppSelection(organizationId);
+    }
+
+    // Convert build number to build ID if provided
+    if (!buildId && buildNumber) {
+      const builds = await appBuildsService.findAll({ appId, numberAsString: buildNumber });
+      if (builds.length === 0) {
+        consola.error(`Build #${buildNumber} not found.`);
+        process.exit(1);
+      }
+      buildId = builds[0]?.id;
+    }
+
+    // Prompt for build ID if not provided
+    if (!buildId) {
+      if (!isInteractive()) {
+        consola.error('You must provide a build ID when running in non-interactive environment.');
+        process.exit(1);
+      }
+      const builds = await appBuildsService.findAll({ appId });
+      if (builds.length === 0) {
+        consola.error('No builds found for this app.');
+        process.exit(1);
+      }
+      // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+      buildId = await prompt('Select the build you want to run:', {
+        type: 'select',
+        options: builds.map((build) => ({
+          label: `Build #${build.numberAsString || build.id} (${build.platform} - ${build.type})`,
+          value: build.id,
+        })),
+      });
+      if (!buildId) {
+        consola.error('You must select a build to run.');
+        process.exit(1);
+      }
+    }
+
+    const build = await appBuildsService.findOne({ appId, appBuildId: buildId, relations: 'appBuildArtifacts,job' });
+    const packageName = validateAppBuild(build);
+
+    const artifactType = build.platform === 'android' ? 'apk' : 'app';
+    const artifact = build.appBuildArtifacts?.find(
+      (artifact) => artifact.type === artifactType && artifact.status === 'ready',
+    );
+    if (!artifact) {
+      consola.error(`No ${artifactType.toUpperCase()} artifact is available for this build.`);
+      process.exit(1);
+    }
+
+    consola.start('Downloading build...');
+    const artifactData = await appBuildsService.downloadArtifact({
+      appId,
+      appBuildId: buildId,
+      artifactId: artifact.id,
+    });
+    const temporaryDirectoryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'capawesome-'));
+    consola.success('Build downloaded.');
+
+    if (build.platform === 'android') {
+      const apkPath = path.join(temporaryDirectoryPath, 'app.apk');
+      await fs.writeFile(apkPath, Buffer.from(artifactData));
+      await handleAndroidRun({ apkPath, deviceName: device, packageName });
+    } else {
+      const appPath = await extractAppBundle(Buffer.from(artifactData), temporaryDirectoryPath);
+      await handleIosRun({ appPath, deviceName: device, packageName });
+    }
+  }),
+});
+
+/**
+ * Ensure the build can be run locally and return its package name.
+ */
+const validateAppBuild = (build: AppBuildDto): string => {
+  if (build.job?.status !== 'succeeded') {
+    consola.error('The build has not succeeded yet. Cannot run incomplete builds.');
+    process.exit(1);
+  }
+  if (build.platform === 'web') {
+    consola.error('Web builds cannot be run on an emulator or simulator.');
+    process.exit(1);
+  }
+  if (build.platform === 'ios') {
+    if (process.platform !== 'darwin') {
+      consola.error('iOS builds can only be run on macOS.');
+      process.exit(1);
+    }
+    if (build.type !== 'simulator') {
+      consola.error(
+        `Only iOS builds of the type "simulator" can be run on a simulator. This build has the type "${build.type}".`,
+      );
+      process.exit(1);
+    }
+  }
+  if (!build.packageName) {
+    consola.error('The package name of this build is unknown. Please create a new build and try again.');
+    process.exit(1);
+  }
+  return build.packageName;
+};
+
+/**
+ * Extract the app bundle from the downloaded artifact and return its path.
+ */
+const extractAppBundle = async (artifactData: Buffer, targetFolder: string): Promise<string> => {
+  await zip.unzipToFolder(artifactData, targetFolder);
+  const entries = await fs.readdir(targetFolder);
+  const appBundleName = entries.find((entry) => entry.endsWith('.app'));
+  if (!appBundleName) {
+    consola.error('The downloaded artifact does not contain an app bundle.');
+    process.exit(1);
+  }
+  return path.join(targetFolder, appBundleName);
+};
+
+/**
+ * Select the device to run the build on, preferring devices that are already running.
+ */
+const selectDevice = async <T>(deviceOptions: DeviceOption<T>[], deviceName?: string): Promise<T> => {
+  const sortedDeviceOptions = [...deviceOptions].sort(
+    (deviceOption, otherDeviceOption) => Number(otherDeviceOption.running) - Number(deviceOption.running),
+  );
+
+  if (deviceName) {
+    const matchingDeviceOption = sortedDeviceOptions.find((deviceOption) => deviceOption.name === deviceName);
+    if (!matchingDeviceOption) {
+      consola.error(`The device "${deviceName}" was not found.`);
+      process.exit(1);
+    }
+    return matchingDeviceOption.device;
+  }
+
+  if (!isInteractive()) {
+    consola.error('You must provide a device when running in non-interactive environment.');
+    process.exit(1);
+  }
+
+  // @ts-ignore wait till https://github.com/unjs/consola/pull/280 is merged
+  const selectedIndex: string = await prompt('Select the device you want to run the build on:', {
+    type: 'select',
+    options: sortedDeviceOptions.map((deviceOption, index) => ({
+      label: deviceOption.running ? `${deviceOption.label} (running)` : deviceOption.label,
+      value: `${index}`,
+    })),
+  });
+
+  const selectedDeviceOption = sortedDeviceOptions[Number(selectedIndex)];
+  if (!selectedDeviceOption) {
+    consola.error('You must select a device to run the build on.');
+    process.exit(1);
+  }
+  return selectedDeviceOption.device;
+};
+
+/**
+ * Run an Android build on a local emulator.
+ */
+const handleAndroidRun = async (options: {
+  apkPath: string;
+  deviceName?: string;
+  packageName: string;
+}): Promise<void> => {
+  const { apkPath, deviceName, packageName } = options;
+
+  const emulators = findAllAndroidEmulators();
+  if (emulators.length === 0) {
+    consola.error('No Android emulators found. Create one in Android Studio and try again.');
+    process.exit(1);
+  }
+  const emulator = await selectDevice(
+    emulators.map((emulator) => ({
+      device: emulator,
+      label: emulator.name,
+      name: emulator.name,
+      running: emulator.running,
+    })),
+    deviceName,
+  );
+
+  consola.start(emulator.running ? `Using emulator "${emulator.name}"...` : `Starting emulator "${emulator.name}"...`);
+  const serial = await bootAndroidEmulator(emulator);
+  consola.success(`Emulator "${emulator.name}" is running.`);
+
+  consola.start('Installing app...');
+  installAndroidApp(serial, apkPath);
+  consola.success('App installed.');
+
+  consola.start('Launching app...');
+  launchAndroidApp(serial, packageName);
+  consola.success('App launched.');
+};
+
+/**
+ * Run an iOS build on a local simulator.
+ */
+const handleIosRun = async (options: { appPath: string; deviceName?: string; packageName: string }): Promise<void> => {
+  const { appPath, deviceName, packageName } = options;
+
+  const simulators = findAllIosSimulators();
+  if (simulators.length === 0) {
+    consola.error('No iOS simulators found. Install one via Xcode and try again.');
+    process.exit(1);
+  }
+  const simulator = await selectDevice(
+    simulators.map((simulator) => ({
+      device: simulator,
+      label: `${simulator.name} (${simulator.runtime})`,
+      name: simulator.name,
+      running: simulator.running,
+    })),
+    deviceName,
+  );
+
+  consola.start(
+    simulator.running ? `Using simulator "${simulator.name}"...` : `Starting simulator "${simulator.name}"...`,
+  );
+  bootIosSimulator(simulator);
+  consola.success(`Simulator "${simulator.name}" is running.`);
+
+  consola.start('Installing app...');
+  installIosApp(simulator.udid, appPath);
+  consola.success('App installed.');
+
+  consola.start('Launching app...');
+  launchIosApp(simulator.udid, packageName);
+  consola.success('App launched.');
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const config = defineConfig({
     'apps:builds:get': await import('@/commands/apps/builds/get.js').then((mod) => mod.default),
     'apps:builds:list': await import('@/commands/apps/builds/list.js').then((mod) => mod.default),
     'apps:builds:logs': await import('@/commands/apps/builds/logs.js').then((mod) => mod.default),
+    'apps:builds:run': await import('@/commands/apps/builds/run.js').then((mod) => mod.default),
     'apps:builds:share': await import('@/commands/apps/builds/share.js').then((mod) => mod.default),
     'apps:builds:unshare': await import('@/commands/apps/builds/unshare.js').then((mod) => mod.default),
     'apps:builds:download': await import('@/commands/apps/builds/download.js').then((mod) => mod.default),

--- a/src/types/app-build.ts
+++ b/src/types/app-build.ts
@@ -6,7 +6,7 @@ export interface AppBuildArtifactDto {
   fileName: string;
   fileSizeInBytes: number;
   status: 'pending' | 'ready';
-  type: 'apk' | 'aab' | 'ipa' | 'zip';
+  type: 'apk' | 'aab' | 'app' | 'ipa' | 'zip';
 }
 
 export interface AppBuildDto {
@@ -22,6 +22,7 @@ export interface AppBuildDto {
   job?: JobDto;
   jobId: string;
   numberAsString: string;
+  packageName: string | null;
   platform: 'ios' | 'android' | 'web';
   type: string;
 }

--- a/src/utils/android-emulator.ts
+++ b/src/utils/android-emulator.ts
@@ -1,0 +1,158 @@
+import { getCodeFromUnknownError, UserError } from '@/utils/error.js';
+import { wait } from '@/utils/wait.js';
+import { execFileSync, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const BOOT_POLL_INTERVAL_IN_MS = 2000;
+const BOOT_TIMEOUT_IN_MS = 300000;
+
+export interface AndroidEmulator {
+  name: string;
+  running: boolean;
+  serial: string | null;
+}
+
+/**
+ * Find all Android emulators (AVDs) installed on this machine.
+ */
+export const findAllAndroidEmulators = (): AndroidEmulator[] => {
+  const names = runEmulator(['-list-avds'])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const serialByName = findAllRunningAndroidEmulators();
+  return names.map((name) => {
+    const serial = serialByName.get(name) ?? null;
+    return { name, running: !!serial, serial };
+  });
+};
+
+/**
+ * Boot an Android emulator and wait until it has finished booting.
+ *
+ * Returns the serial of the running emulator.
+ */
+export const bootAndroidEmulator = async (emulator: AndroidEmulator): Promise<string> => {
+  if (emulator.serial) {
+    return emulator.serial;
+  }
+  const child = spawn(getAndroidToolPath('emulator', 'emulator'), ['-avd', emulator.name], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+  const deadline = Date.now() + BOOT_TIMEOUT_IN_MS;
+  while (Date.now() < deadline) {
+    await wait(BOOT_POLL_INTERVAL_IN_MS);
+    const serial = findAllRunningAndroidEmulators().get(emulator.name);
+    if (serial && isAndroidEmulatorBooted(serial)) {
+      return serial;
+    }
+  }
+  throw new UserError(`The emulator "${emulator.name}" did not finish booting in time.`);
+};
+
+/**
+ * Install an APK on a running Android emulator.
+ */
+export const installAndroidApp = (serial: string, apkPath: string): void => {
+  runAdb(['-s', serial, 'install', '-r', apkPath]);
+};
+
+/**
+ * Launch an app on a running Android emulator.
+ */
+export const launchAndroidApp = (serial: string, packageName: string): void => {
+  runAdb(['-s', serial, 'shell', 'monkey', '-p', packageName, '-c', 'android.intent.category.LAUNCHER', '1']);
+};
+
+/**
+ * Map the AVD name of every running emulator to its serial.
+ */
+const findAllRunningAndroidEmulators = (): Map<string, string> => {
+  const serials = runAdb(['devices'])
+    .split('\n')
+    .slice(1)
+    .map((line) => line.split('\t')[0]?.trim())
+    .filter((serial) => !!serial && serial.startsWith('emulator-'));
+  const serialByName = new Map<string, string>();
+  for (const serial of serials) {
+    if (!serial) {
+      continue;
+    }
+    try {
+      const name = runAdb(['-s', serial, 'emu', 'avd', 'name']).split('\n')[0]?.trim();
+      if (name) {
+        serialByName.set(name, serial);
+      }
+    } catch {
+      // Ignore emulators that do not respond to the console command.
+    }
+  }
+  return serialByName;
+};
+
+const isAndroidEmulatorBooted = (serial: string): boolean => {
+  try {
+    return runAdb(['-s', serial, 'shell', 'getprop', 'sys.boot_completed']).trim() === '1';
+  } catch {
+    return false;
+  }
+};
+
+const runAdb = (args: string[]): string => run(getAndroidToolPath('platform-tools', 'adb'), args, 'adb');
+
+const runEmulator = (args: string[]): string => run(getAndroidToolPath('emulator', 'emulator'), args, 'emulator');
+
+const run = (command: string, args: string[], toolName: string): string => {
+  try {
+    return execFileSync(command, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    if (getCodeFromUnknownError(error) === 'ENOENT') {
+      throw new UserError(
+        `Could not find "${toolName}". Make sure the Android SDK is installed and the ANDROID_HOME environment variable is set.`,
+      );
+    }
+    const stderr = (error as { stderr?: string }).stderr?.trim();
+    throw new UserError(stderr ? `The command "${toolName}" failed: ${stderr}` : `The command "${toolName}" failed.`);
+  }
+};
+
+/**
+ * Resolve an Android SDK tool, falling back to the `PATH` if the SDK cannot be located.
+ */
+const getAndroidToolPath = (directory: string, binary: string): string => {
+  const sdkRoot = getAndroidSdkRoot();
+  if (sdkRoot) {
+    const toolPath = path.join(sdkRoot, directory, binary);
+    if (fs.existsSync(toolPath)) {
+      return toolPath;
+    }
+  }
+  return binary;
+};
+
+const getAndroidSdkRoot = (): string | undefined => {
+  const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+  if (sdkRoot) {
+    return sdkRoot;
+  }
+  const defaultSdkRoot = getDefaultAndroidSdkRoot();
+  return fs.existsSync(defaultSdkRoot) ? defaultSdkRoot : undefined;
+};
+
+const getDefaultAndroidSdkRoot = (): string => {
+  switch (process.platform) {
+    case 'darwin': {
+      return path.join(os.homedir(), 'Library', 'Android', 'sdk');
+    }
+    case 'win32': {
+      return path.join(os.homedir(), 'AppData', 'Local', 'Android', 'Sdk');
+    }
+    default: {
+      return path.join(os.homedir(), 'Android', 'Sdk');
+    }
+  }
+};

--- a/src/utils/android-emulator.ts
+++ b/src/utils/android-emulator.ts
@@ -9,8 +9,10 @@ const BOOT_POLL_INTERVAL_IN_MS = 2000;
 const BOOT_TIMEOUT_IN_MS = 300000;
 
 export interface AndroidEmulator {
+  id: string;
   name: string;
   running: boolean;
+  sdkVersion: string | null;
   serial: string | null;
 }
 
@@ -18,14 +20,21 @@ export interface AndroidEmulator {
  * Find all Android emulators (AVDs) installed on this machine.
  */
 export const findAllAndroidEmulators = (): AndroidEmulator[] => {
-  const names = runEmulator(['-list-avds'])
+  const ids = runEmulator(['-list-avds'])
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean);
-  const serialByName = findAllRunningAndroidEmulators();
-  return names.map((name) => {
-    const serial = serialByName.get(name) ?? null;
-    return { name, running: !!serial, serial };
+  const serialById = findAllRunningAndroidEmulators();
+  return ids.map((id) => {
+    const serial = serialById.get(id) ?? null;
+    const { displayName, sdkVersion } = getAndroidEmulatorConfig(id);
+    return {
+      id,
+      name: displayName ?? id,
+      running: !!serial,
+      sdkVersion,
+      serial,
+    };
   });
 };
 
@@ -38,7 +47,7 @@ export const bootAndroidEmulator = async (emulator: AndroidEmulator): Promise<st
   if (emulator.serial) {
     return emulator.serial;
   }
-  const child = spawn(getAndroidToolPath('emulator', 'emulator'), ['-avd', emulator.name], {
+  const child = spawn(getAndroidToolPath('emulator', 'emulator'), ['-avd', emulator.id], {
     detached: true,
     stdio: 'ignore',
   });
@@ -46,7 +55,7 @@ export const bootAndroidEmulator = async (emulator: AndroidEmulator): Promise<st
   const deadline = Date.now() + BOOT_TIMEOUT_IN_MS;
   while (Date.now() < deadline) {
     await wait(BOOT_POLL_INTERVAL_IN_MS);
-    const serial = findAllRunningAndroidEmulators().get(emulator.name);
+    const serial = findAllRunningAndroidEmulators().get(emulator.id);
     if (serial && isAndroidEmulatorBooted(serial)) {
       return serial;
     }
@@ -69,7 +78,7 @@ export const launchAndroidApp = (serial: string, packageName: string): void => {
 };
 
 /**
- * Map the AVD name of every running emulator to its serial.
+ * Map the AVD ID of every running emulator to its serial.
  */
 const findAllRunningAndroidEmulators = (): Map<string, string> => {
   const serials = runAdb(['devices'])
@@ -77,21 +86,45 @@ const findAllRunningAndroidEmulators = (): Map<string, string> => {
     .slice(1)
     .map((line) => line.split('\t')[0]?.trim())
     .filter((serial) => !!serial && serial.startsWith('emulator-'));
-  const serialByName = new Map<string, string>();
+  const serialById = new Map<string, string>();
   for (const serial of serials) {
     if (!serial) {
       continue;
     }
     try {
-      const name = runAdb(['-s', serial, 'emu', 'avd', 'name']).split('\n')[0]?.trim();
-      if (name) {
-        serialByName.set(name, serial);
+      const id = runAdb(['-s', serial, 'emu', 'avd', 'name']).split('\n')[0]?.trim();
+      if (id) {
+        serialById.set(id, serial);
       }
     } catch {
       // Ignore emulators that do not respond to the console command.
     }
   }
-  return serialByName;
+  return serialById;
+};
+
+/**
+ * Read the display name and API level of an emulator from its AVD configuration.
+ */
+const getAndroidEmulatorConfig = (id: string): { displayName: string | null; sdkVersion: string | null } => {
+  try {
+    const config = fs.readFileSync(path.join(getAndroidAvdHome(), `${id}.avd`, 'config.ini'), 'utf-8');
+    return {
+      displayName: config.match(/^avd\.ini\.displayname=(.+)$/m)?.[1]?.trim() ?? null,
+      sdkVersion: config.match(/android-(\d+)/)?.[1] ?? null,
+    };
+  } catch {
+    return { displayName: null, sdkVersion: null };
+  }
+};
+
+const getAndroidAvdHome = (): string => {
+  const avdHome = process.env.ANDROID_AVD_HOME;
+  if (avdHome) {
+    return avdHome;
+  }
+  const sdkHome = process.env.ANDROID_SDK_HOME;
+  return sdkHome ? path.join(sdkHome, '.android', 'avd') : path.join(os.homedir(), '.android', 'avd');
 };
 
 const isAndroidEmulatorBooted = (serial: string): boolean => {
@@ -112,7 +145,7 @@ const run = (command: string, args: string[], toolName: string): string => {
   } catch (error) {
     if (getCodeFromUnknownError(error) === 'ENOENT') {
       throw new UserError(
-        `Could not find "${toolName}". Make sure the Android SDK is installed and the ANDROID_HOME environment variable is set.`,
+        `Could not find "${toolName}". Make sure the Android SDK is installed and either the ANDROID_HOME or ANDROID_SDK_ROOT environment variable points to it.`,
       );
     }
     const stderr = (error as { stderr?: string }).stderr?.trim();

--- a/src/utils/ios-simulator.ts
+++ b/src/utils/ios-simulator.ts
@@ -1,0 +1,78 @@
+import { getCodeFromUnknownError, UserError } from '@/utils/error.js';
+import { execFileSync } from 'child_process';
+
+interface SimctlDevice {
+  name: string;
+  state: string;
+  udid: string;
+}
+
+export interface IosSimulator {
+  name: string;
+  runtime: string;
+  running: boolean;
+  udid: string;
+}
+
+/**
+ * Find all available iOS simulators installed on this machine.
+ */
+export const findAllIosSimulators = (): IosSimulator[] => {
+  const output = runSimctl(['list', 'devices', 'available', '--json']);
+  const devicesByRuntime = (JSON.parse(output).devices ?? {}) as Record<string, SimctlDevice[]>;
+  return Object.entries(devicesByRuntime)
+    .filter(([runtime]) => runtime.includes('iOS'))
+    .flatMap(([runtime, devices]) =>
+      devices.map((device) => ({
+        name: device.name,
+        runtime: getRuntimeName(runtime),
+        running: device.state === 'Booted',
+        udid: device.udid,
+      })),
+    );
+};
+
+/**
+ * Boot an iOS simulator, wait until it has finished booting and bring it to the front.
+ */
+export const bootIosSimulator = (simulator: IosSimulator): void => {
+  runSimctl(['bootstatus', simulator.udid, '-b']);
+  run('open', ['-a', 'Simulator'], 'open');
+};
+
+/**
+ * Install an app bundle on a booted iOS simulator.
+ */
+export const installIosApp = (udid: string, appPath: string): void => {
+  runSimctl(['install', udid, appPath]);
+};
+
+/**
+ * Launch an app on a booted iOS simulator.
+ */
+export const launchIosApp = (udid: string, packageName: string): void => {
+  runSimctl(['launch', udid, packageName]);
+};
+
+/**
+ * Convert a simulator runtime identifier into a readable name (e.g. `iOS 18.2`).
+ */
+const getRuntimeName = (runtime: string): string => {
+  const identifier = runtime.split('.').pop() ?? runtime;
+  const [platform, ...version] = identifier.split('-');
+  return version.length > 0 ? `${platform} ${version.join('.')}` : identifier;
+};
+
+const runSimctl = (args: string[]): string => run('xcrun', ['simctl', ...args], 'simctl');
+
+const run = (command: string, args: string[], toolName: string): string => {
+  try {
+    return execFileSync(command, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    if (getCodeFromUnknownError(error) === 'ENOENT') {
+      throw new UserError(`Could not find "${toolName}". Make sure Xcode is installed.`);
+    }
+    const stderr = (error as { stderr?: string }).stderr?.trim();
+    throw new UserError(stderr ? `The command "${toolName}" failed: ${stderr}` : `The command "${toolName}" failed.`);
+  }
+};

--- a/src/utils/ios-simulator.ts
+++ b/src/utils/ios-simulator.ts
@@ -8,10 +8,10 @@ interface SimctlDevice {
 }
 
 export interface IosSimulator {
+  id: string;
   name: string;
-  runtime: string;
   running: boolean;
-  udid: string;
+  sdkVersion: string;
 }
 
 /**
@@ -24,10 +24,10 @@ export const findAllIosSimulators = (): IosSimulator[] => {
     .filter(([runtime]) => runtime.includes('iOS'))
     .flatMap(([runtime, devices]) =>
       devices.map((device) => ({
+        id: device.udid,
         name: device.name,
-        runtime: getRuntimeName(runtime),
         running: device.state === 'Booted',
-        udid: device.udid,
+        sdkVersion: getRuntimeVersion(runtime),
       })),
     );
 };
@@ -36,31 +36,31 @@ export const findAllIosSimulators = (): IosSimulator[] => {
  * Boot an iOS simulator, wait until it has finished booting and bring it to the front.
  */
 export const bootIosSimulator = (simulator: IosSimulator): void => {
-  runSimctl(['bootstatus', simulator.udid, '-b']);
+  runSimctl(['bootstatus', simulator.id, '-b']);
   run('open', ['-a', 'Simulator'], 'open');
 };
 
 /**
  * Install an app bundle on a booted iOS simulator.
  */
-export const installIosApp = (udid: string, appPath: string): void => {
-  runSimctl(['install', udid, appPath]);
+export const installIosApp = (id: string, appPath: string): void => {
+  runSimctl(['install', id, appPath]);
 };
 
 /**
  * Launch an app on a booted iOS simulator.
  */
-export const launchIosApp = (udid: string, packageName: string): void => {
-  runSimctl(['launch', udid, packageName]);
+export const launchIosApp = (id: string, packageName: string): void => {
+  runSimctl(['launch', id, packageName]);
 };
 
 /**
- * Convert a simulator runtime identifier into a readable name (e.g. `iOS 18.2`).
+ * Extract the version from a simulator runtime identifier (e.g. `18.2`).
  */
-const getRuntimeName = (runtime: string): string => {
+const getRuntimeVersion = (runtime: string): string => {
   const identifier = runtime.split('.').pop() ?? runtime;
-  const [platform, ...version] = identifier.split('-');
-  return version.length > 0 ? `${platform} ${version.join('.')}` : identifier;
+  const [, ...version] = identifier.split('-');
+  return version.join('.');
 };
 
 const runSimctl = (args: string[]): string => run('xcrun', ['simctl', ...args], 'simctl');

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -6,12 +6,18 @@ import path from 'path';
 const MAX_ZIP_ENTRIES = 65535;
 
 interface Zip {
+  unzipToFolder(buffer: Buffer, targetFolder: string): Promise<void>;
   zipFolder(sourceFolder: string): Promise<Buffer>;
   zipFolderWithGitignore(sourceFolder: string): Promise<Buffer>;
   isZipped(path: string): boolean;
 }
 
 class ZipImpl implements Zip {
+  async unzipToFolder(buffer: Buffer, targetFolder: string): Promise<void> {
+    const zip = new AdmZip(buffer);
+    zip.extractAllTo(targetFolder, true);
+  }
+
   async zipFolder(sourceFolder: string): Promise<Buffer> {
     const zip = new AdmZip();
     zip.addLocalFolder(sourceFolder);


### PR DESCRIPTION
Adds `apps:builds:run`, which downloads a successful build, boots a local emulator or simulator, then installs and launches the app.

```
npx @capawesome/cli apps:builds:run --app-id <id> --build-number 42
```

Part of capawesome-team/cloud#95.

## Supported builds

| Platform | Build type | Artifact |
| --- | --- | --- |
| Android | `debug`, `release` | `apk` |
| iOS | `simulator` only | `app` |

Other iOS build types produce device-signed IPAs that cannot be installed with `simctl`, and web builds have nothing to run, so both are rejected with an explanatory error.

## Options

- `--app-id` — app the build belongs to. Prompts when omitted.
- `--build-id` — build to run.
- `--build-number` — build to run, by number (e.g. `42`). Prompts when neither is given.
- `--list` — print the target devices available for the build and exit.
- `--target <id>` — run on a specific target device by ID (AVD ID on Android, UDID on iOS).
- `--target-name <name>` — run on a specific target device by name (e.g. `"Pixel 8 Pro"`, `"iPhone 17 Pro"`).
- `--target-name-sdk-version <version>` — used with `--target-name` to pick between targets that share a name but differ in OS version (e.g. `18.2` for iOS 18.2, `35` for Android API 35).

## Target selection

Targets that are already running are listed first and marked `(running)`, so the common case is a single keypress and no boot wait:

```
? Select the target device you want to run the build on: ›
❯ Pixel 8 Pro (API 34) (running)
  Pixel 9 Pro (API 35)
```

Selecting a running target skips the boot step. A target flag bypasses the prompt and is required in non-interactive environments. `--target-name-sdk-version` without `--target-name` is rejected up front, and an ambiguous `--target-name` warns and points at `--target`.

## Implementation

- `utils/android-emulator.ts` — lists AVDs via `emulator -list-avds`, reads the display name and API level from each AVD's `config.ini`, maps running emulators back to their AVD ID with `adb -s <serial> emu avd name`, boots detached and polls `sys.boot_completed`, installs with `adb install -r`, launches via `monkey`. SDK tools are resolved from `ANDROID_HOME`/`ANDROID_SDK_ROOT` or the platform default location, falling back to `PATH`.
- `utils/ios-simulator.ts` — lists simulators via `simctl list devices available --json`, boots with `bootstatus -b`, installs and launches with `simctl`.
- `utils/zip.ts` — adds `unzipToFolder`, used to unpack the `.app` bundle. The downloaded artifact is extracted into a temp directory that is removed again once the app is installed.
- `types/app-build.ts` — adds the `app` artifact type and `packageName`.

No new dependencies.

## Notes

Android distinguishes the AVD **ID** (`Pixel_8_Pro`, what `emulator -avd` needs) from its **display name** (`Pixel 8 Pro`, what users recognise). `--target` matches the former, `--target-name` the latter.

The package name comes from `build.packageName`, which is populated by the build runner (capawesome-team/cloud-tart-worker-script#62). That change needs to ship first — until it does, builds have no package name and the command exits with a message asking for a new build.

## Testing

`npm run build`, `npm run lint` and `npm test` pass (229 tests). The command itself was not executed end to end, since that needs a real emulator and a successful cloud build.
