### PR TITLE
feat: send `X-Capawesome-Installation-Id` header on API requests

### DIFF
--- a/src/utils/http-client.test.ts
+++ b/src/utils/http-client.test.ts
@@ -1,4 +1,5 @@
 import configService from '@/services/config.js';
+import { getInstallationId } from '@/utils/installation-id.js';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,6 +8,10 @@ vi.mock('@/services/config.js', () => ({
   default: {
     getValueForKey: vi.fn().mockResolvedValue('https://api.example.com'),
   },
+}));
+
+vi.mock('@/utils/installation-id.js', () => ({
+  getInstallationId: vi.fn().mockReturnValue('aa4b5a1c-1d0e-4a51-9c8f-3f1b2d9e7a10'),
 }));
 
 describe('http-client', () => {
@@ -120,6 +125,52 @@ describe('http-client', () => {
 
     expect(response.status).toBe(200);
     expect(response.data).toEqual({ success: true });
+  });
+
+  it('should send the installation id header on API requests', async () => {
+    vi.mocked(configService.getValueForKey).mockResolvedValue('https://api.example.com');
+
+    nock('https://api.example.com', {
+      reqheaders: { 'x-capawesome-installation-id': 'aa4b5a1c-1d0e-4a51-9c8f-3f1b2d9e7a10' },
+    })
+      .get('/installation-id')
+      .reply(200, { success: true });
+
+    const { default: httpClient } = await import('./http-client.js');
+
+    const response = await httpClient.get('/installation-id');
+
+    expect(response.status).toBe(200);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('should omit the installation id header when it is not available', async () => {
+    vi.mocked(configService.getValueForKey).mockResolvedValue('https://api.example.com');
+    vi.mocked(getInstallationId).mockReturnValueOnce(undefined);
+
+    nock('https://api.example.com', { badheaders: ['x-capawesome-installation-id'] })
+      .get('/no-installation-id')
+      .reply(200, { success: true });
+
+    const { default: httpClient } = await import('./http-client.js');
+
+    const response = await httpClient.get('/no-installation-id');
+
+    expect(response.status).toBe(200);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('should not send the installation id header to third-party hosts', async () => {
+    nock('https://registry.example.com', { badheaders: ['x-capawesome-installation-id'] })
+      .get('/package')
+      .reply(200, { success: true });
+
+    const { default: httpClient } = await import('./http-client.js');
+
+    const response = await httpClient.get('https://registry.example.com/package');
+
+    expect(response.status).toBe(200);
+    expect(nock.isDone()).toBe(true);
   });
 
   // Note: Testing actual proxy behavior with nock is not reliable as nock intercepts

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'module';
 import configService from '@/services/config.js';
+import { getInstallationId } from '@/utils/installation-id.js';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { HttpProxyAgent } from 'http-proxy-agent';
@@ -48,73 +49,58 @@ export interface HttpClient {
 }
 
 class HttpClientImpl implements HttpClient {
-  private readonly baseHeaders = {
-    'User-Agent': `Capawesome CLI v${pkg.version}`,
-  };
-
   async delete<T>(url: string, config?: AxiosRequestConfig<any> | undefined): Promise<AxiosResponse<T>> {
-    const baseUrl = await configService.getValueForKey('API_BASE_URL');
-    const urlWithHost = url.startsWith('http') ? url : baseUrl + url;
-    const proxyAgent = getProxyAgent(urlWithHost);
-    const axiosConfig: AxiosRequestConfig = {
-      ...config,
-      headers: { ...this.baseHeaders, ...config?.headers },
-      ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
-      ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
-    };
-    return axios.delete<T>(urlWithHost, axiosConfig);
+    const request = await this.createRequest(url, config);
+    return axios.delete<T>(request.url, request.config);
   }
 
   async get<T>(url: string, config?: AxiosRequestConfig<any> | undefined): Promise<AxiosResponse<T>> {
-    const baseUrl = await configService.getValueForKey('API_BASE_URL');
-    const urlWithHost = url.startsWith('http') ? url : baseUrl + url;
-    const proxyAgent = getProxyAgent(urlWithHost);
-    const axiosConfig: AxiosRequestConfig = {
-      ...config,
-      headers: { ...this.baseHeaders, ...config?.headers },
-      ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
-      ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
-    };
-    return axios.get<T>(urlWithHost, axiosConfig);
+    const request = await this.createRequest(url, config);
+    return axios.get<T>(request.url, request.config);
   }
 
   async patch<T>(url: string, data?: any, config?: AxiosRequestConfig<any> | undefined): Promise<AxiosResponse<T>> {
-    const baseUrl = await configService.getValueForKey('API_BASE_URL');
-    const urlWithHost = url.startsWith('http') ? url : baseUrl + url;
-    const proxyAgent = getProxyAgent(urlWithHost);
-    const axiosConfig: AxiosRequestConfig = {
-      ...config,
-      headers: { ...this.baseHeaders, ...config?.headers },
-      ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
-      ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
-    };
-    return axios.patch<T>(urlWithHost, data, axiosConfig);
+    const request = await this.createRequest(url, config);
+    return axios.patch<T>(request.url, data, request.config);
   }
 
   async post<T>(url: string, data?: any, config?: AxiosRequestConfig<any> | undefined): Promise<AxiosResponse<T>> {
-    const baseUrl = await configService.getValueForKey('API_BASE_URL');
-    const urlWithHost = url.startsWith('http') ? url : baseUrl + url;
-    const proxyAgent = getProxyAgent(urlWithHost);
-    const axiosConfig: AxiosRequestConfig = {
-      ...config,
-      headers: { ...this.baseHeaders, ...config?.headers },
-      ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
-      ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
-    };
-    return axios.post<T>(urlWithHost, data, axiosConfig);
+    const request = await this.createRequest(url, config);
+    return axios.post<T>(request.url, data, request.config);
   }
 
   async put<T>(url: string, data?: any, config?: AxiosRequestConfig<any> | undefined): Promise<AxiosResponse<T>> {
+    const request = await this.createRequest(url, config);
+    return axios.put<T>(request.url, data, request.config);
+  }
+
+  private async createRequest(
+    url: string,
+    config: AxiosRequestConfig<any> | undefined,
+  ): Promise<{ config: AxiosRequestConfig; url: string }> {
+    // Only relative urls target the Capawesome API. Absolute urls point to third parties
+    // (e.g. the npm registry) and must not receive the installation id.
+    const isApiRequest = !url.startsWith('http');
     const baseUrl = await configService.getValueForKey('API_BASE_URL');
-    const urlWithHost = url.startsWith('http') ? url : baseUrl + url;
+    const urlWithHost = isApiRequest ? baseUrl + url : url;
     const proxyAgent = getProxyAgent(urlWithHost);
-    const axiosConfig: AxiosRequestConfig = {
-      ...config,
-      headers: { ...this.baseHeaders, ...config?.headers },
-      ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
-      ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
+    return {
+      config: {
+        ...config,
+        headers: { ...this.createBaseHeaders(isApiRequest), ...config?.headers },
+        ...(proxyAgent && urlWithHost.startsWith('https://') ? { httpsAgent: proxyAgent, proxy: false } : {}),
+        ...(proxyAgent && urlWithHost.startsWith('http://') ? { httpAgent: proxyAgent, proxy: false } : {}),
+      },
+      url: urlWithHost,
     };
-    return axios.put<T>(urlWithHost, data, axiosConfig);
+  }
+
+  private createBaseHeaders(isApiRequest: boolean): Record<string, string> {
+    const installationId = isApiRequest ? getInstallationId() : undefined;
+    return {
+      'User-Agent': `Capawesome CLI v${pkg.version}`,
+      ...(installationId ? { 'X-Capawesome-Installation-Id': installationId } : {}),
+    };
   }
 }
 

--- a/src/utils/installation-id.test.ts
+++ b/src/utils/installation-id.test.ts
@@ -1,0 +1,66 @@
+import userConfig from '@/utils/user-config.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/user-config.js');
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('getInstallationId', () => {
+  const mockRead = vi.mocked(userConfig.read);
+  const mockWrite = vi.mocked(userConfig.write);
+
+  // The installation id is cached in a module-level variable, so the module has to be
+  // reimported for every test.
+  const importGetInstallationId = async () => {
+    vi.resetModules();
+    return (await import('./installation-id.js')).getInstallationId;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRead.mockReturnValue({});
+  });
+
+  it('should generate and persist a random uuid on first use', async () => {
+    mockRead.mockReturnValue({ token: 'abc' });
+    const getInstallationId = await importGetInstallationId();
+
+    const installationId = getInstallationId();
+
+    expect(installationId).toMatch(UUID_PATTERN);
+    expect(mockWrite).toHaveBeenCalledWith({ token: 'abc', installationId });
+  });
+
+  it('should return the persisted installation id without writing it again', async () => {
+    mockRead.mockReturnValue({ installationId: 'aa4b5a1c-1d0e-4a51-9c8f-3f1b2d9e7a10' });
+    const getInstallationId = await importGetInstallationId();
+
+    expect(getInstallationId()).toBe('aa4b5a1c-1d0e-4a51-9c8f-3f1b2d9e7a10');
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it('should read the config only once', async () => {
+    const getInstallationId = await importGetInstallationId();
+
+    expect(getInstallationId()).toBe(getInstallationId());
+    expect(mockRead).toHaveBeenCalledOnce();
+  });
+
+  it('should return undefined when the config cannot be read', async () => {
+    mockRead.mockImplementation(() => {
+      throw new Error('read failed');
+    });
+    const getInstallationId = await importGetInstallationId();
+
+    expect(getInstallationId()).toBeUndefined();
+  });
+
+  it('should return undefined when the installation id cannot be persisted', async () => {
+    mockWrite.mockImplementation(() => {
+      throw new Error('write failed');
+    });
+    const getInstallationId = await importGetInstallationId();
+
+    expect(getInstallationId()).toBeUndefined();
+  });
+});

--- a/src/utils/installation-id.ts
+++ b/src/utils/installation-id.ts
@@ -1,0 +1,33 @@
+import userConfig from '@/utils/user-config.js';
+import { randomUUID } from 'node:crypto';
+
+let cachedInstallationId: string | undefined;
+
+/**
+ * Returns the random id of this CLI installation, generating and persisting it on first use.
+ *
+ * The id must stay an opaque random UUID. Never derive it from the hostname, MAC address,
+ * user name or any other machine property, as it is sent to the API on every request.
+ *
+ * Returns `undefined` if the id can neither be read nor persisted, in which case the API
+ * falls back to identifying the installation by the user agent.
+ */
+export function getInstallationId(): string | undefined {
+  if (cachedInstallationId) {
+    return cachedInstallationId;
+  }
+  try {
+    const config = userConfig.read();
+    if (config.installationId) {
+      cachedInstallationId = config.installationId;
+      return cachedInstallationId;
+    }
+    const installationId = randomUUID();
+    userConfig.write({ ...config, installationId });
+    cachedInstallationId = installationId;
+    return installationId;
+  } catch {
+    // Never let a missing installation id break a request.
+    return undefined;
+  }
+}

--- a/src/utils/user-config.ts
+++ b/src/utils/user-config.ts
@@ -4,6 +4,9 @@ import { resolve } from 'node:path';
 import { readUser, writeUser } from 'rc9';
 
 export interface IUserConfig {
+  // The random id of this CLI installation, sent to the API to recognize logins
+  // from a new machine. See `@/utils/installation-id.js`.
+  installationId?: string;
   // The non-secret id of the active session, persisted so `logout` can delete
   // the correct session. The session token is kept in the secure credential store.
   sessionId?: string;


### PR DESCRIPTION
## Motivation

The API identifies the machine behind a request by parsing the `User-Agent`. The CLI sends `Capawesome CLI vX.Y.Z`, and once the version is stripped (otherwise every upgrade would look like a new machine), nothing is left that varies — every CLI installation produces the same identity. After a user's first CLI login, a CLI login from any other machine raises no alert.

## Changes

- Add `getInstallationId()` (`src/utils/installation-id.ts`), which returns the random UUID identifying this CLI installation, generating and persisting it in the existing `~/.capawesome` config on first use. The id is cached in memory, so the config file is read once per process.
- Send it as `X-Capawesome-Installation-Id` on every request to the Capawesome API.
- Extract the duplicated url/proxy/header assembly in `HttpClientImpl` into a shared `createRequest()` method, so the header only had to be added in one place.

Notes on the behavior:

- The id survives CLI upgrades, since it lives in the user config rather than in the installed package.
- It is per installation, not per user or per project. Two machines get two ids, and a reinstall generates a new one.
- It is an opaque random UUID (`randomUUID()`). Nothing is derived from the hostname, MAC address or user name.
- Absolute urls are excluded, so the id is not sent to third parties such as the npm registry during the update check.
- If the config can neither be read nor written, the header is omitted rather than regenerated per run, and the API falls back to the user agent.

The header is optional and purely additive, so older CLI versions keep working unchanged.

## Release note

This release changes the machine identity for everyone who upgrades, so each active CLI user receives one "new device" email. Worth calling out in the changelog so it does not read as a security incident.