### PR TITLE
chore(deps): replace deprecated `@robingenz/zli` with `zodline`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
       "dependencies": {
         "@clack/prompts": "0.7.0",
         "@napi-rs/keyring": "1.3.0",
-        "@robingenz/zli": "0.2.0",
         "@sentry/node": "10.58.0",
         "adm-zip": "0.6.0",
         "axios": "1.18.1",
@@ -37,7 +36,8 @@
         "rc9": "2.1.2",
         "semver": "7.6.3",
         "systeminformation": "5.31.17",
-        "zod": "4.0.17"
+        "zod": "4.0.17",
+        "zodline": "0.3.0"
       },
       "bin": {
         "capawesome": "dist/index.js"
@@ -679,21 +679,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@robingenz/zli": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@robingenz/zli/-/zli-0.2.0.tgz",
-      "integrity": "sha512-LME7G4xkEFuqyVg/MYTB3xoJnvWb955aEfZ7J7yRstzyULs3HBdxz0l5QiP8gmMMMZ434cb8Wn/DdHqeNTT2fA==",
-      "license": "MIT",
-      "bin": {
-        "zli-example": "example.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -4242,6 +4227,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zodline": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/zodline/-/zodline-0.3.0.tgz",
+      "integrity": "sha512-9F3EY7xp9DIztEaM1Jnz+rN9aBuCt3RZaPGpOEEIx3nak2ISRvBDplPBfjVWkWs+ZV68+ZP90qRGUDzW/vZxDQ==",
+      "license": "MIT",
+      "bin": {
+        "zodline-example": "example.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "dependencies": {
     "@clack/prompts": "0.7.0",
     "@napi-rs/keyring": "1.3.0",
-    "@robingenz/zli": "0.2.0",
     "@sentry/node": "10.58.0",
     "adm-zip": "0.6.0",
     "axios": "1.18.1",
@@ -73,7 +72,8 @@
     "rc9": "2.1.2",
     "semver": "7.6.3",
     "systeminformation": "5.31.17",
-    "zod": "4.0.17"
+    "zod": "4.0.17",
+    "zodline": "0.3.0"
   },
   "devDependencies": {
     "@ionic/prettier-config": "4.0.0",

--- a/src/commands/apps/automations/create.ts
+++ b/src/commands/apps/automations/create.ts
@@ -3,9 +3,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app automation.',

--- a/src/commands/apps/automations/delete.ts
+++ b/src/commands/apps/automations/delete.ts
@@ -2,9 +2,9 @@ import appAutomationsService from '@/services/app-automations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app automation.',

--- a/src/commands/apps/automations/get.ts
+++ b/src/commands/apps/automations/get.ts
@@ -3,9 +3,9 @@ import { AppAutomationDto } from '@/types/app-automation.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app automation.',

--- a/src/commands/apps/automations/list.ts
+++ b/src/commands/apps/automations/list.ts
@@ -2,9 +2,9 @@ import appAutomationsService from '@/services/app-automations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'List all automations for an app.',

--- a/src/commands/apps/automations/update.ts
+++ b/src/commands/apps/automations/update.ts
@@ -2,9 +2,9 @@ import appAutomationsService from '@/services/app-automations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 const clearableValue = (value: string | undefined): string | null | undefined => (value === '' ? null : value);
 

--- a/src/commands/apps/builds/cancel.ts
+++ b/src/commands/apps/builds/cancel.ts
@@ -3,9 +3,9 @@ import jobsService from '@/services/jobs.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Cancel an app build.',

--- a/src/commands/apps/builds/create.ts
+++ b/src/commands/apps/builds/create.ts
@@ -16,11 +16,11 @@ import { isDirectory, isReadable } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 const IOS_BUILD_TYPES = ['simulator', 'development', 'ad-hoc', 'app-store', 'enterprise'] as const;
 const ANDROID_BUILD_TYPES = ['debug', 'release'] as const;

--- a/src/commands/apps/builds/download.ts
+++ b/src/commands/apps/builds/download.ts
@@ -1,12 +1,12 @@
 import appBuildsService from '@/services/app-builds.js';
 import { withAuth } from '@/utils/auth.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs/promises';
 import path from 'path';
 import { isInteractive } from '@/utils/environment.js';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Download an app build.',

--- a/src/commands/apps/builds/failure-summary.ts
+++ b/src/commands/apps/builds/failure-summary.ts
@@ -3,9 +3,9 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { printJobFailureSummary } from '@/utils/job-failure-summary.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Explain why an app build failed using Capawesome Cloud Assist (AI).',

--- a/src/commands/apps/builds/get.ts
+++ b/src/commands/apps/builds/get.ts
@@ -1,8 +1,8 @@
 import appBuildsService from '@/services/app-builds.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app build.',

--- a/src/commands/apps/builds/list.ts
+++ b/src/commands/apps/builds/list.ts
@@ -2,9 +2,9 @@ import appBuildsService from '@/services/app-builds.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing app builds.',

--- a/src/commands/apps/builds/logs.ts
+++ b/src/commands/apps/builds/logs.ts
@@ -3,10 +3,10 @@ import { unescapeAnsi } from '@/utils/ansi.js';
 import { withAuth } from '@/utils/auth.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { wait } from '@/utils/wait.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { isInteractive } from '@/utils/environment.js';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Show logs of an app build.',

--- a/src/commands/apps/builds/run.ts
+++ b/src/commands/apps/builds/run.ts
@@ -1,5 +1,6 @@
 import appBuildsService from '@/services/app-builds.js';
 import { AppBuildDto } from '@/types/app-build.js';
+import { defineCommand, defineOptions } from 'zodline';
 import {
   AndroidEmulator,
   bootAndroidEmulator,
@@ -18,7 +19,6 @@ import {
 } from '@/utils/ios-simulator.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs/promises';
 import os from 'os';

--- a/src/commands/apps/builds/share.ts
+++ b/src/commands/apps/builds/share.ts
@@ -3,9 +3,9 @@ import { getAppBuildShareUrls } from '@/utils/app-build-shares.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a public share link for an app build.',

--- a/src/commands/apps/builds/unshare.ts
+++ b/src/commands/apps/builds/unshare.ts
@@ -2,9 +2,9 @@ import appBuildsService from '@/services/app-builds.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Revoke the public share link of an app build.',

--- a/src/commands/apps/bundles/create.ts
+++ b/src/commands/apps/bundles/create.ts
@@ -1,6 +1,6 @@
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app bundle. Deprecated, use the `apps:liveupdates` commands instead.',

--- a/src/commands/apps/bundles/delete.ts
+++ b/src/commands/apps/bundles/delete.ts
@@ -1,6 +1,6 @@
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app bundle. Deprecated.',

--- a/src/commands/apps/bundles/update.ts
+++ b/src/commands/apps/bundles/update.ts
@@ -1,6 +1,6 @@
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update an app bundle. Deprecated.',

--- a/src/commands/apps/certificates/create.ts
+++ b/src/commands/apps/certificates/create.ts
@@ -5,11 +5,11 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app certificate.',

--- a/src/commands/apps/certificates/delete.ts
+++ b/src/commands/apps/certificates/delete.ts
@@ -2,9 +2,9 @@ import appCertificatesService from '@/services/app-certificates.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app certificate.',

--- a/src/commands/apps/certificates/get.ts
+++ b/src/commands/apps/certificates/get.ts
@@ -2,9 +2,9 @@ import appCertificatesService from '@/services/app-certificates.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app certificate.',

--- a/src/commands/apps/certificates/list.ts
+++ b/src/commands/apps/certificates/list.ts
@@ -2,9 +2,9 @@ import appCertificatesService from '@/services/app-certificates.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing app certificates.',

--- a/src/commands/apps/certificates/update.ts
+++ b/src/commands/apps/certificates/update.ts
@@ -2,9 +2,9 @@ import appCertificatesService from '@/services/app-certificates.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update an existing app certificate.',

--- a/src/commands/apps/channels/create.ts
+++ b/src/commands/apps/channels/create.ts
@@ -3,9 +3,9 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { getMessageFromUnknownError } from '@/utils/error.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app channel.',

--- a/src/commands/apps/channels/delete.ts
+++ b/src/commands/apps/channels/delete.ts
@@ -1,10 +1,10 @@
 import appChannelsService from '@/services/app-channels.js';
 import { withAuth } from '@/utils/auth.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { isInteractive } from '@/utils/environment.js';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app channel.',

--- a/src/commands/apps/channels/get.ts
+++ b/src/commands/apps/channels/get.ts
@@ -1,9 +1,9 @@
 import appChannelsService from '@/services/app-channels.js';
 import { AppChannelDto } from '@/types/index.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app channel.',

--- a/src/commands/apps/channels/list.ts
+++ b/src/commands/apps/channels/list.ts
@@ -2,9 +2,9 @@ import appChannelsService from '@/services/app-channels.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing app channels.',

--- a/src/commands/apps/channels/pause.ts
+++ b/src/commands/apps/channels/pause.ts
@@ -2,9 +2,9 @@ import appChannelsService from '@/services/app-channels.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Pause an app channel.',

--- a/src/commands/apps/channels/resume.ts
+++ b/src/commands/apps/channels/resume.ts
@@ -2,9 +2,9 @@ import appChannelsService from '@/services/app-channels.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Resume an app channel.',

--- a/src/commands/apps/channels/update.ts
+++ b/src/commands/apps/channels/update.ts
@@ -2,9 +2,9 @@ import appChannelsService from '@/services/app-channels.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update an existing app channel.',

--- a/src/commands/apps/configurations/create.ts
+++ b/src/commands/apps/configurations/create.ts
@@ -2,9 +2,9 @@ import appConfigurationsService from '@/services/app-configurations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new native configuration.',

--- a/src/commands/apps/configurations/delete.ts
+++ b/src/commands/apps/configurations/delete.ts
@@ -2,9 +2,9 @@ import appConfigurationsService from '@/services/app-configurations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete a native configuration.',

--- a/src/commands/apps/configurations/get.ts
+++ b/src/commands/apps/configurations/get.ts
@@ -3,9 +3,9 @@ import { AppConfigurationDto } from '@/types/app-configuration.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing native configuration.',

--- a/src/commands/apps/configurations/list.ts
+++ b/src/commands/apps/configurations/list.ts
@@ -2,9 +2,9 @@ import appConfigurationsService from '@/services/app-configurations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'List all native configurations for an app.',

--- a/src/commands/apps/configurations/update.ts
+++ b/src/commands/apps/configurations/update.ts
@@ -2,9 +2,9 @@ import appConfigurationsService from '@/services/app-configurations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update an existing native configuration.',

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -3,9 +3,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app.',

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -2,9 +2,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app.',

--- a/src/commands/apps/deployments/cancel.ts
+++ b/src/commands/apps/deployments/cancel.ts
@@ -3,9 +3,9 @@ import jobsService from '@/services/jobs.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Cancel an ongoing app deployment.',

--- a/src/commands/apps/deployments/create.ts
+++ b/src/commands/apps/deployments/create.ts
@@ -7,9 +7,9 @@ import { isInteractive } from '@/utils/environment.js';
 import { offerJobFailureSummary } from '@/utils/job-failure-summary.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app deployment on Capawesome Cloud.',

--- a/src/commands/apps/deployments/failure-summary.ts
+++ b/src/commands/apps/deployments/failure-summary.ts
@@ -3,9 +3,9 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { printJobFailureSummary } from '@/utils/job-failure-summary.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Explain why an app deployment failed using Capawesome Cloud Assist (AI).',

--- a/src/commands/apps/deployments/get.ts
+++ b/src/commands/apps/deployments/get.ts
@@ -1,8 +1,8 @@
 import appDeploymentsService from '@/services/app-deployments.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app deployment.',

--- a/src/commands/apps/deployments/list.ts
+++ b/src/commands/apps/deployments/list.ts
@@ -2,9 +2,9 @@ import appDeploymentsService from '@/services/app-deployments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing app deployments.',

--- a/src/commands/apps/deployments/logs.ts
+++ b/src/commands/apps/deployments/logs.ts
@@ -3,10 +3,10 @@ import { unescapeAnsi } from '@/utils/ansi.js';
 import { withAuth } from '@/utils/auth.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { wait } from '@/utils/wait.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { isInteractive } from '@/utils/environment.js';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'View the deployment logs of an app.',

--- a/src/commands/apps/destinations/create.ts
+++ b/src/commands/apps/destinations/create.ts
@@ -6,11 +6,11 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new app destination.',

--- a/src/commands/apps/destinations/delete.ts
+++ b/src/commands/apps/destinations/delete.ts
@@ -2,9 +2,9 @@ import appDestinationsService from '@/services/app-destinations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app destination.',

--- a/src/commands/apps/destinations/get.ts
+++ b/src/commands/apps/destinations/get.ts
@@ -2,9 +2,9 @@ import appDestinationsService from '@/services/app-destinations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app destination.',

--- a/src/commands/apps/destinations/list.ts
+++ b/src/commands/apps/destinations/list.ts
@@ -2,9 +2,9 @@ import appDestinationsService from '@/services/app-destinations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing app destinations.',

--- a/src/commands/apps/destinations/update.ts
+++ b/src/commands/apps/destinations/update.ts
@@ -2,9 +2,9 @@ import appDestinationsService from '@/services/app-destinations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update an existing app destination.',

--- a/src/commands/apps/devices/delete.ts
+++ b/src/commands/apps/devices/delete.ts
@@ -1,10 +1,10 @@
 import appDevicesService from '@/services/app-devices.js';
 import { withAuth } from '@/utils/auth.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { isInteractive } from '@/utils/environment.js';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an app device.',

--- a/src/commands/apps/devices/forcechannel.ts
+++ b/src/commands/apps/devices/forcechannel.ts
@@ -3,9 +3,9 @@ import appDevicesService from '@/services/app-devices.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Force a device to use a specific channel.',

--- a/src/commands/apps/devices/probe.ts
+++ b/src/commands/apps/devices/probe.ts
@@ -2,10 +2,10 @@ import appDevicesService from '@/services/app-devices.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import { AxiosError } from 'axios';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Check whether a device would receive a live update.',

--- a/src/commands/apps/devices/unforcechannel.ts
+++ b/src/commands/apps/devices/unforcechannel.ts
@@ -2,9 +2,9 @@ import appDevicesService from '@/services/app-devices.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Remove the forced channel from a device.',

--- a/src/commands/apps/environments/create.ts
+++ b/src/commands/apps/environments/create.ts
@@ -2,9 +2,9 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new environment.',

--- a/src/commands/apps/environments/delete.ts
+++ b/src/commands/apps/environments/delete.ts
@@ -2,9 +2,9 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Delete an environment.',

--- a/src/commands/apps/environments/get.ts
+++ b/src/commands/apps/environments/get.ts
@@ -3,9 +3,9 @@ import { AppEnvironmentDto } from '@/types/app-environment.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing environment.',

--- a/src/commands/apps/environments/list.ts
+++ b/src/commands/apps/environments/list.ts
@@ -2,9 +2,9 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'List all environments for an app.',

--- a/src/commands/apps/environments/set.ts
+++ b/src/commands/apps/environments/set.ts
@@ -4,10 +4,10 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { isReadable } from '@/utils/file.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Set environment variables and secrets.',

--- a/src/commands/apps/environments/unset.ts
+++ b/src/commands/apps/environments/unset.ts
@@ -2,9 +2,9 @@ import appEnvironmentsService from '@/services/app-environments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Unset environment variables and secrets.',

--- a/src/commands/apps/get.ts
+++ b/src/commands/apps/get.ts
@@ -1,8 +1,8 @@
 import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing app.',

--- a/src/commands/apps/link.ts
+++ b/src/commands/apps/link.ts
@@ -3,9 +3,9 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { getGitRemoteInfo } from '@/utils/git.js';
 import { promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Connect a git repository to an app.',

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -2,9 +2,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing apps.',

--- a/src/commands/apps/liveupdates/bundle.ts
+++ b/src/commands/apps/liveupdates/bundle.ts
@@ -1,4 +1,5 @@
 import { isInteractive } from '@/utils/environment.js';
+import { defineCommand, defineOptions } from 'zodline';
 import {
   directoryContainsSourceMaps,
   directoryContainsSymlinks,
@@ -9,7 +10,6 @@ import {
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs';
 import pathModule from 'path';

--- a/src/commands/apps/liveupdates/create.ts
+++ b/src/commands/apps/liveupdates/create.ts
@@ -12,11 +12,11 @@ import { isReadable } from '@/utils/file.js';
 import { waitForJobCompletion } from '@/utils/job.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new live update by building and deploying web assets using Capawesome Cloud Runners.',

--- a/src/commands/apps/liveupdates/generate-manifest.ts
+++ b/src/commands/apps/liveupdates/generate-manifest.ts
@@ -2,9 +2,9 @@ import { isInteractive } from '@/utils/environment.js';
 import { directoryContainsSourceMaps, directoryContainsSymlinks, isReadable, isDirectory } from '@/utils/file.js';
 import { generateManifestJson } from '@/utils/manifest.js';
 import { prompt } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Generate a manifest file.',

--- a/src/commands/apps/liveupdates/generate-signing-key.ts
+++ b/src/commands/apps/liveupdates/generate-signing-key.ts
@@ -1,10 +1,10 @@
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { promises as fs } from 'fs';
 import pathModule from 'path';
 import { z } from 'zod';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt } from '@/utils/prompt.js';
+import { defineCommand, defineOptions } from 'zodline';
 
 const APP_TYPES = ['capacitor', 'cordova'] as const;
 type SigningKeyAppType = (typeof APP_TYPES)[number];

--- a/src/commands/apps/liveupdates/register.ts
+++ b/src/commands/apps/liveupdates/register.ts
@@ -11,9 +11,9 @@ import { formatPrivateKey } from '@/utils/private-key.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { createSignature } from '@/utils/signature.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Register a self-hosted bundle URL for serving artifacts from your own infrastructure.',

--- a/src/commands/apps/liveupdates/rollback.ts
+++ b/src/commands/apps/liveupdates/rollback.ts
@@ -5,9 +5,9 @@ import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { formatTimeAgo } from '@/utils/time-format.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Rollback the active build in a channel to a previous build.',

--- a/src/commands/apps/liveupdates/rollout.ts
+++ b/src/commands/apps/liveupdates/rollout.ts
@@ -4,9 +4,9 @@ import appDeploymentsService from '@/services/app-deployments.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Update the rollout percentage of the active build in a channel.',

--- a/src/commands/apps/liveupdates/set-native-versions.ts
+++ b/src/commands/apps/liveupdates/set-native-versions.ts
@@ -1,9 +1,9 @@
 import appBuildsService from '@/services/app-builds.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Set native version constraints on a web build.',

--- a/src/commands/apps/liveupdates/upload.ts
+++ b/src/commands/apps/liveupdates/upload.ts
@@ -5,6 +5,7 @@ import appsService from '@/services/apps.js';
 import { AppBundleFileDto } from '@/types/app-bundle-file.js';
 import { withAuth } from '@/utils/auth.js';
 import { parseCustomProperties } from '@/utils/custom-properties.js';
+import { defineCommand, defineOptions } from 'zodline';
 import {
   createBufferFromPath,
   createBufferFromReadStream,
@@ -25,7 +26,6 @@ import { formatPrivateKey } from '@/utils/private-key.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
 import { createSignature } from '@/utils/signature.js';
 import zip from '@/utils/zip.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { createReadStream } from 'fs';
 import pathModule from 'path';

--- a/src/commands/apps/transfer.ts
+++ b/src/commands/apps/transfer.ts
@@ -2,9 +2,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Transfer an app to another organization.',

--- a/src/commands/apps/unlink.ts
+++ b/src/commands/apps/unlink.ts
@@ -2,9 +2,9 @@ import appsService from '@/services/apps.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt, promptAppSelection, promptOrganizationSelection } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Disconnect a git repository from an app.',

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'module';
-import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
 import systeminformation from 'systeminformation';
+import { defineCommand } from 'zodline';
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,11 +7,11 @@ import { isInteractive } from '@/utils/environment.js';
 import { prompt } from '@/utils/prompt.js';
 import credentialStore from '@/utils/credential-store.js';
 import userConfig from '@/utils/user-config.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import { AxiosError } from 'axios';
 import consola from 'consola';
 import open from 'open';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Sign in to the Capawesome Cloud Console.',

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,9 +1,9 @@
-import { defineCommand } from '@robingenz/zli';
 import consola from 'consola';
 import authorizationService from '@/services/authorization-service.js';
 import sessionsService from '@/services/sessions.js';
 import credentialStore from '@/utils/credential-store.js';
 import userConfig from '@/utils/user-config.js';
+import { defineCommand } from 'zodline';
 
 export default defineCommand({
   description: 'Sign out from the Capawesome Cloud Console.',

--- a/src/commands/manifests/generate.ts
+++ b/src/commands/manifests/generate.ts
@@ -1,6 +1,6 @@
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Generate a manifest file. Deprecated, use `apps:liveupdates:generate-manifest` instead.',

--- a/src/commands/organizations/create.ts
+++ b/src/commands/organizations/create.ts
@@ -2,9 +2,9 @@ import organizationsService from '@/services/organizations.js';
 import { withAuth } from '@/utils/auth.js';
 import { isInteractive } from '@/utils/environment.js';
 import { prompt } from '@/utils/prompt.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Create a new organization.',

--- a/src/commands/organizations/get.ts
+++ b/src/commands/organizations/get.ts
@@ -1,8 +1,8 @@
 import organizationsService from '@/services/organizations.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Get an existing organization.',

--- a/src/commands/organizations/list.ts
+++ b/src/commands/organizations/list.ts
@@ -1,8 +1,8 @@
 import organizationsService from '@/services/organizations.js';
 import { withAuth } from '@/utils/auth.js';
-import { defineCommand, defineOptions } from '@robingenz/zli';
 import consola from 'consola';
 import { z } from 'zod';
+import { defineCommand, defineOptions } from 'zodline';
 
 export default defineCommand({
   description: 'Retrieve a list of existing organizations.',

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,8 +1,8 @@
 import authorizationService from '@/services/authorization-service.js';
 import usersService from '@/services/users.js';
-import { defineCommand } from '@robingenz/zli';
 import { AxiosError } from 'axios';
 import consola from 'consola';
+import { defineCommand } from 'zodline';
 
 export default defineCommand({
   description: 'Show current user',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'module';
-import { defineConfig, processConfig } from '@robingenz/zli';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineConfig, processConfig } from 'zodline';
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,12 @@ import telemetryService from '@/services/telemetry.js';
 import updateService from '@/services/update.js';
 import { getMessageFromUnknownError, UserError } from '@/utils/error.js';
 import userConfig from '@/utils/user-config.js';
-import { defineConfig, processConfig, ZliError } from '@robingenz/zli';
 import * as Sentry from '@sentry/node';
 import { AxiosError } from 'axios';
 import consola from 'consola';
 import { createRequire } from 'module';
 import { ZodError } from 'zod';
+import { defineConfig, processConfig, ZodlineError } from 'zodline';
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 
@@ -121,7 +121,7 @@ const captureException = async (error: unknown) => {
     return;
   }
   // Ignore errors from the CLI itself (e.g. "No command found.")
-  if (error instanceof ZliError) {
+  if (error instanceof ZodlineError) {
     return;
   }
   // Ignore validation errors


### PR DESCRIPTION
The `@robingenz/zli` package has been deprecated and renamed to `zodline`. This PR migrates the CLI to the new package.

## Changes

- Replaced the `@robingenz/zli@0.2.0` dependency with `zodline@0.3.0`.
- Updated the import specifier from `@robingenz/zli` to `zodline` in all 82 affected source files.
- Renamed the `ZliError` class to `ZodlineError`, including the `instanceof` check in `src/index.ts`.

No behavioral changes — `defineConfig`, `defineCommand`, `defineOptions` and `processConfig` are unchanged in `zodline@0.3.0`.

## Verification

- `npm run lint` passes.
- `npm run build` passes.
- `npm test` passes (254 tests).