### PR TITLE
fix(uploads): lower multipart upload threshold to 10 MB

### DIFF
--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -3,3 +3,5 @@ export const DEFAULT_CONSOLE_BASE_URL = 'https://console.cloud.capawesome.io';
 export const MANIFEST_JSON_FILE_NAME = 'capawesome-live-update-manifest.json'; // Do NOT change this!
 export const MAX_CONCURRENT_FILE_UPLOADS = 20;
 export const MAX_CONCURRENT_PART_UPLOADS = 4;
+export const MULTIPART_UPLOAD_THRESHOLD_IN_BYTES = 10 * 1024 * 1024; // 10 MB
+export const UPLOAD_PART_SIZE_IN_BYTES = 10 * 1024 * 1024; // 10 MB. 5 MB is the minimum part size except for the last part.

--- a/src/services/app-build-sources.ts
+++ b/src/services/app-build-sources.ts
@@ -1,4 +1,4 @@
-import { MAX_CONCURRENT_PART_UPLOADS } from '@/config/index.js';
+import { MAX_CONCURRENT_PART_UPLOADS, UPLOAD_PART_SIZE_IN_BYTES } from '@/config/index.js';
 import authorizationService from '@/services/authorization-service.js';
 import { AppBuildSourceDto, CreateAppBuildSourceDto } from '@/types/app-build-source.js';
 import httpClient, { HttpClient } from '@/utils/http-client.js';
@@ -110,8 +110,7 @@ class AppBuildSourcesServiceImpl implements AppBuildSourcesService {
     onProgress?: (currentPart: number, totalParts: number) => void,
   ): Promise<AppBuildSourceUploadPartDto[]> {
     const uploadedParts: AppBuildSourceUploadPartDto[] = [];
-    const partSize = 10 * 1024 * 1024; // 10 MB
-    const totalParts = Math.ceil(dto.buffer.byteLength / partSize);
+    const totalParts = Math.ceil(dto.buffer.byteLength / UPLOAD_PART_SIZE_IN_BYTES);
     let partNumber = 0;
     const uploadNextPart = async () => {
       if (partNumber >= totalParts) {
@@ -119,8 +118,8 @@ class AppBuildSourcesServiceImpl implements AppBuildSourcesService {
       }
       partNumber++;
       onProgress?.(partNumber, totalParts);
-      const start = (partNumber - 1) * partSize;
-      const end = Math.min(start + partSize, dto.buffer.byteLength);
+      const start = (partNumber - 1) * UPLOAD_PART_SIZE_IN_BYTES;
+      const end = Math.min(start + UPLOAD_PART_SIZE_IN_BYTES, dto.buffer.byteLength);
       const partBuffer = dto.buffer.subarray(start, end);
 
       const uploadedPart = await this.createUploadPart({

--- a/src/services/app-bundle-files.ts
+++ b/src/services/app-bundle-files.ts
@@ -1,4 +1,8 @@
-import { MAX_CONCURRENT_PART_UPLOADS } from '@/config/index.js';
+import {
+  MAX_CONCURRENT_PART_UPLOADS,
+  MULTIPART_UPLOAD_THRESHOLD_IN_BYTES,
+  UPLOAD_PART_SIZE_IN_BYTES,
+} from '@/config/index.js';
 import authorizationService from '@/services/authorization-service.js';
 import { AppBundleFileDto, CreateAppBundleFileDto } from '@/types/app-bundle-file.js';
 import httpClient, { HttpClient } from '@/utils/http-client.js';
@@ -23,7 +27,7 @@ class AppBundleFilesServiceImpl implements AppBundleFilesService {
     onProgress?: (currentPart: number, totalParts: number) => void,
   ): Promise<AppBundleFileDto> {
     const sizeInBytes = dto.buffer.byteLength;
-    const useMultipartUpload = sizeInBytes >= 10 * 1024 * 1024; // 10 MB
+    const useMultipartUpload = sizeInBytes >= MULTIPART_UPLOAD_THRESHOLD_IN_BYTES;
     const formData = new FormData();
     formData.append('checksum', dto.checksum);
     if (!useMultipartUpload) {
@@ -117,8 +121,7 @@ class AppBundleFilesServiceImpl implements AppBundleFilesService {
     onProgress?: (currentPart: number, totalParts: number) => void,
   ): Promise<AppBundleFileUploadPartDto[]> {
     const uploadedParts: AppBundleFileUploadPartDto[] = [];
-    const partSize = 10 * 1024 * 1024; // 10 MB. 5 MB is the minimum part size except for the last part.
-    const totalParts = Math.ceil(dto.buffer.byteLength / partSize);
+    const totalParts = Math.ceil(dto.buffer.byteLength / UPLOAD_PART_SIZE_IN_BYTES);
     let partNumber = 0;
     const uploadNextPart = async () => {
       if (partNumber >= totalParts) {
@@ -126,8 +129,8 @@ class AppBundleFilesServiceImpl implements AppBundleFilesService {
       }
       partNumber++;
       onProgress?.(partNumber, totalParts);
-      const start = (partNumber - 1) * partSize;
-      const end = Math.min(start + partSize, dto.buffer.byteLength);
+      const start = (partNumber - 1) * UPLOAD_PART_SIZE_IN_BYTES;
+      const end = Math.min(start + UPLOAD_PART_SIZE_IN_BYTES, dto.buffer.byteLength);
       const partBuffer = dto.buffer.subarray(start, end);
 
       const uploadedPart = await this.createUploadPart({

--- a/src/services/app-bundle-files.ts
+++ b/src/services/app-bundle-files.ts
@@ -23,7 +23,7 @@ class AppBundleFilesServiceImpl implements AppBundleFilesService {
     onProgress?: (currentPart: number, totalParts: number) => void,
   ): Promise<AppBundleFileDto> {
     const sizeInBytes = dto.buffer.byteLength;
-    const useMultipartUpload = sizeInBytes >= 50 * 1024 * 1024; // 50 MB
+    const useMultipartUpload = sizeInBytes >= 10 * 1024 * 1024; // 10 MB
     const formData = new FormData();
     formData.append('checksum', dto.checksum);
     if (!useMultipartUpload) {


### PR DESCRIPTION
App bundle files switched to a multipart upload only from 50 MB. This lowers that threshold to 10 MB, so it now matches the part size used by `createUploadParts`.

Files below 10 MB are still sent inline in the `FormData` of the create request; from 10 MB the file is uploaded in parts.

Note: `app-build-sources.ts` is unchanged and still always uses a multipart upload. Its create endpoint only accepts `fileSizeInBytes` or `fileUrl`, so there is no inline-file path to fall back to for small files.